### PR TITLE
Fix cancelling jobs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -307,6 +307,7 @@ val joexapi = project.in(file("modules/joexapi")).
     name := "docspell-joexapi",
     libraryDependencies ++=
       Dependencies.circe ++
+      Dependencies.http4sCirce ++
       Dependencies.http4sClient,
     openapiTargetLanguage := Language.Scala,
     openapiPackage := Pkg("docspell.joexapi.model"),

--- a/modules/common/src/main/scala/docspell/common/JobState.scala
+++ b/modules/common/src/main/scala/docspell/common/JobState.scala
@@ -20,7 +20,7 @@ object JobState {
   /** Is currently executing */
   case object Running extends JobState {}
 
-  /** Finished with failure and is being retried. */
+  /** Task completed with failure and is being retried. */
   case object Stuck extends JobState {}
 
   /** Finished finally with a failure */
@@ -34,8 +34,9 @@ object JobState {
 
   val all: Set[JobState] =
     Set(Waiting, Scheduled, Running, Stuck, Failed, Cancelled, Success)
-  val queued: Set[JobState] = Set(Waiting, Scheduled, Stuck)
-  val done: Set[JobState]   = Set(Failed, Cancelled, Success)
+  val queued: Set[JobState]     = Set(Waiting, Scheduled, Stuck)
+  val done: Set[JobState]       = Set(Failed, Cancelled, Success)
+  val inProgress: Set[JobState] = Set(Scheduled, Running, Stuck)
 
   def parse(str: String): Either[String, JobState] =
     str.toLowerCase match {

--- a/modules/joex/src/main/scala/docspell/joex/process/ProcessItem.scala
+++ b/modules/joex/src/main/scala/docspell/joex/process/ProcessItem.scala
@@ -30,5 +30,4 @@ object ProcessItem {
       .flatMap(FindProposal[F](cfg.processing))
       .flatMap(EvalProposals[F])
       .flatMap(SaveProposals[F])
-
 }

--- a/modules/joexapi/src/main/scala/docspell/joexapi/client/JoexClient.scala
+++ b/modules/joexapi/src/main/scala/docspell/joexapi/client/JoexClient.scala
@@ -4,9 +4,11 @@ import cats.implicits._
 import cats.effect._
 import docspell.common.{Ident, LenientUri}
 import docspell.common.syntax.all._
+import docspell.joexapi.model.BasicResult
 import org.http4s.{Method, Request, Uri}
 import org.http4s.client.Client
 import org.http4s.client.blaze.BlazeClientBuilder
+import org.http4s.circe.CirceEntityDecoder._
 import scala.concurrent.ExecutionContext
 
 import org.log4s.getLogger
@@ -17,7 +19,7 @@ trait JoexClient[F[_]] {
 
   def notifyJoexIgnoreErrors(base: LenientUri): F[Unit]
 
-  def cancelJob(base: LenientUri, job: Ident): F[Unit]
+  def cancelJob(base: LenientUri, job: Ident): F[BasicResult]
 
 }
 
@@ -44,10 +46,10 @@ object JoexClient {
             ()
         }
 
-      def cancelJob(base: LenientUri, job: Ident): F[Unit] = {
+      def cancelJob(base: LenientUri, job: Ident): F[BasicResult] = {
         val cancelUrl = base / "api" / "v1" / "job" / job.id / "cancel"
         val req       = Request[F](Method.POST, uri(cancelUrl))
-        client.expect[String](req).map(_ => ())
+        client.expect[BasicResult](req)
       }
 
       private def uri(u: LenientUri): Uri =

--- a/modules/microsite/docs/doc/processing.md
+++ b/modules/microsite/docs/doc/processing.md
@@ -36,7 +36,7 @@ that a job is some time waiting until it is picked up by a job
 executor. You can always start more job executors to help out.
 
 If a job fails, it is retried after some time. Only if it fails too
-often (can be configured), it then is finished with *failed* state. If
-processing finally fails, the item is still created, just without
-suggestions. But if processing is cancelled by the user, the item is
-not created.
+often (can be configured), it then is finished with *failed* state.
+
+For the document-processing task, if processing finally fails or a job
+is cancelled, the item is still created, just without suggestions.

--- a/modules/store/src/main/scala/docspell/store/records/RJob.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RJob.scala
@@ -31,6 +31,12 @@ case class RJob(
 
   def info: String =
     s"${id.id.substring(0, 9)}.../${group.id}/${task.id}/$priority"
+
+  def isFinalState: Boolean =
+    JobState.done.contains(state)
+
+  def isInProgress: Boolean =
+    JobState.inProgress.contains(state)
 }
 
 object RJob {
@@ -120,6 +126,12 @@ object RJob {
 
   def findByIdAndGroup(jobId: Ident, jobGroup: Ident): ConnectionIO[Option[RJob]] =
     selectSimple(all, table, and(id.is(jobId), group.is(jobGroup))).query[RJob].option
+
+  def findById(jobId: Ident): ConnectionIO[Option[RJob]] =
+    selectSimple(all, table, id.is(jobId)).query[RJob].option
+
+  def findByIdAndWorker(jobId: Ident, workerId: Ident): ConnectionIO[Option[RJob]] =
+    selectSimple(all, table, and(id.is(jobId), worker.is(workerId))).query[RJob].option
 
   def setRunningToWaiting(workerId: Ident): ConnectionIO[Int] = {
     val states: Seq[JobState] = List(JobState.Running, JobState.Scheduled)


### PR DESCRIPTION
A request to cancel a job was not processed correctly. The cancelling
routine of a task must run, regardless of the (non-final) state. Now
it works like this: if a job is currently running, it is interrupted
and its cancel routine is invoked. It then enters "cancelled" state.
If it is stuck, it is loaded and only its cancel routine is run. If it
is in a final state or waiting, it is removed from the queue.