### PR TITLE
Fix datepicker position for action input fields

### DIFF
--- a/modules/webapp/src/main/elm/Comp/ItemDetail.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail.elm
@@ -2208,7 +2208,7 @@ item visible. This message will disappear then.
                     ]
                 , Html.map DirDropdownMsg (Comp.Dropdown.view settings model.directionModel)
                 ]
-            , div [ class " field" ]
+            , div [ class "field" ]
                 [ label []
                     [ Icons.dateIcon "grey"
                     , text "Date"

--- a/modules/webapp/src/main/webjar/docspell.css
+++ b/modules/webapp/src/main/webjar/docspell.css
@@ -262,6 +262,12 @@ label span.muted {
    From: https://github.com/CurrySoftware/elm-datepicker/blob/3.1.0/css/elm-datepicker.css
    License: BSD-3-Clause
 */
+
+.elm-datepicker--container.ui.input .elm-datepicker--picker {
+    top: 2.7em;
+}
+
+
 .elm-datepicker--container {
   position: relative; }
 


### PR DESCRIPTION
Either the width and appearance must be changed to match this of an
`ui action input` or the position must be fixed as done here. It is
not correctly positioned, because the `ui input` class uses a flex.

See #186 