### PR TITLE
Sort tag list by count

### DIFF
--- a/modules/webapp/src/main/elm/Page/CollectiveSettings/View.elm
+++ b/modules/webapp/src/main/elm/Page/CollectiveSettings/View.elm
@@ -136,7 +136,11 @@ viewInsights model =
             [ text "Tags"
             ]
         , div [ class "ui statistics" ]
-            (List.map makeTagStats model.insights.tagCloud.items)
+            (List.map makeTagStats
+                (List.sortBy .count model.insights.tagCloud.items
+                    |> List.reverse
+                )
+            )
         ]
     ]
 


### PR DESCRIPTION
It was displayed in some random order. Now the most used tag is first.