### PR TITLE
Fixes a race condition when initializing the calendar-event field

### DIFF
--- a/modules/webapp/src/main/elm/Comp/CalEventInput.elm
+++ b/modules/webapp/src/main/elm/Comp/CalEventInput.elm
@@ -2,6 +2,7 @@ module Comp.CalEventInput exposing
     ( Model
     , Msg
     , init
+    , initDefault
     , update
     , view
     )
@@ -34,6 +35,11 @@ type Msg
     | SetMinute String
     | SetWeekday String
     | CheckInputMsg CalEvent (Result Http.Error CalEventCheckResult)
+
+
+initDefault : Model
+initDefault =
+    Model Nothing
 
 
 init : Flags -> CalEvent -> ( Model, Cmd Msg )

--- a/modules/webapp/src/main/elm/Comp/NotificationForm.elm
+++ b/modules/webapp/src/main/elm/Comp/NotificationForm.elm
@@ -133,8 +133,8 @@ init flags =
         initialSchedule =
             Data.Validated.Unknown Data.CalEvent.everyMonth
 
-        ( sm, sc ) =
-            Comp.CalEventInput.init flags Data.CalEvent.everyMonth
+        sm =
+            Comp.CalEventInput.initDefault
     in
     ( { settings = Api.Model.NotificationSettings.empty
       , connectionModel =
@@ -159,7 +159,6 @@ init flags =
     , Cmd.batch
         [ Api.getMailSettings flags "" ConnResp
         , Api.getTags flags "" GetTagsResp
-        , Cmd.map CalEventMsg sc
         ]
     )
 

--- a/modules/webapp/src/main/elm/Comp/ScanMailboxForm.elm
+++ b/modules/webapp/src/main/elm/Comp/ScanMailboxForm.elm
@@ -136,8 +136,8 @@ init flags =
         initialSchedule =
             Data.Validated.Unknown Data.CalEvent.everyMonth
 
-        ( sm, sc ) =
-            Comp.CalEventInput.init flags Data.CalEvent.everyMonth
+        sm =
+            Comp.CalEventInput.initDefault
     in
     ( { settings = Api.Model.ScanMailboxSettings.empty
       , connectionModel =
@@ -168,7 +168,6 @@ init flags =
       }
     , Cmd.batch
         [ Api.getImapSettings flags "" ConnResp
-        , Cmd.map CalEventMsg sc
         , Api.getFolders flags "" False GetFolderResp
         ]
     )


### PR DESCRIPTION
The problem was that the field executes a request to validate its
state. This was initiated at the same time for two values. Then it was
undetermined which value comes back first.