### PR TITLE
Add counter to joblog for correct log order

### DIFF
--- a/modules/store/src/main/resources/db/migration/h2/V1.9.3__joblog_counter.sql
+++ b/modules/store/src/main/resources/db/migration/h2/V1.9.3__joblog_counter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "joblog"
+ADD COLUMN "counter" bigint auto_increment;

--- a/modules/store/src/main/resources/db/migration/mariadb/V1.9.3__joblog_counter.sql
+++ b/modules/store/src/main/resources/db/migration/mariadb/V1.9.3__joblog_counter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `joblog`
+ADD COLUMN `counter` mediumint auto_increment unique;

--- a/modules/store/src/main/resources/db/migration/postgresql/V1.9.3__joblog_counter.sql
+++ b/modules/store/src/main/resources/db/migration/postgresql/V1.9.3__joblog_counter.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "joblog"
+ADD COLUMN "counter" bigserial;

--- a/modules/store/src/main/scala/docspell/store/records/RJobLog.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RJobLog.scala
@@ -26,6 +26,10 @@ object RJobLog {
     val created = Column("created")
     val message = Column("message")
     val all     = List(id, jobId, level, created, message)
+
+    // separate column only for sorting, so not included in `all` and
+    // the case class
+    val counter = Column("counter")
   }
   import Columns._
 
@@ -37,7 +41,7 @@ object RJobLog {
     ).update.run
 
   def findLogs(id: Ident): ConnectionIO[Vector[RJobLog]] =
-    (selectSimple(all, table, jobId.is(id)) ++ orderBy(created.asc))
+    (selectSimple(all, table, jobId.is(id)) ++ orderBy(created.asc, counter.asc))
       .query[RJobLog]
       .to[Vector]
 


### PR DESCRIPTION
This is to distinguish log entries created at the same time.