### PR TITLE
Fix openapi spec for rest-server

### DIFF
--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -1855,7 +1855,7 @@ paths:
       security:
         - authTokenHeader: []
       parameters:
-        - $ref: "#/components/parameters/id"
+        - $ref: "#/components/parameters/itemId"
       requestBody:
         content:
           application/json:
@@ -3995,6 +3995,8 @@ components:
       required:
         - tagsInclude
         - tagsExclude
+        - tagCategoriesInclude
+        - tagCategoriesExclude
         - inbox
         - offset
         - limit


### PR DESCRIPTION
- The `itemId` parameter was not declared for
  `item/{itemId}/reprocess`
- `tagCategories*` must be declared required for `ItemSearch`
  structure

Fixes #338 