### PR TITLE
Fix regex patterns used for NER

### DIFF
--- a/modules/joex/src/main/scala/docspell/joex/process/FindProposal.scala
+++ b/modules/joex/src/main/scala/docspell/joex/process/FindProposal.scala
@@ -232,7 +232,7 @@ object FindProposal {
 
   // The backslash *must* be stripped from search strings.
   private[this] val invalidSearch =
-    "…_[]^<>=&ſ/{}*?@#$|~`+%\"';\\".toSet
+    "…[]^<>=ſ{}|`\"';\\".toSet
 
   private def normalizeSearchValue(str: String): String =
     str.toLowerCase.filter(c => !invalidSearch.contains(c))

--- a/modules/joex/src/test/scala/docspell/joex/analysis/NerFileTest.scala
+++ b/modules/joex/src/test/scala/docspell/joex/analysis/NerFileTest.scala
@@ -1,0 +1,33 @@
+package docspell.joex.analysis
+
+import minitest._
+import NerFile.Pattern
+import java.{util => ju}
+
+object NerFileTest extends SimpleTestSuite {
+
+  test("create valid case insensitive patterns") {
+    val names = List(
+      "Some company AG"            -> "(?i)some company ag",
+      "Acme GmbH"                  -> "(?i)acme gmbh",
+      "UP"                         -> "(?i)up",
+      "1 & 1"                      -> "(?i)1 & 1",
+      "1 & 1 (Telefon / Internet)" -> "(?i)1 & 1 \\(telefon / internet\\)",
+      "X-corp (this)*-*[one]"      -> "(?i)x\\-corp \\(this\\)\\*\\-\\*\\[one\\]"
+    )
+
+    for ((name, first) <- names) {
+      val ps = Pattern(1)(name).distinct
+      //check if it compiles to a regex pattern
+      ps.flatMap(_.value.split("\\s+").toList).foreach(_.r)
+      ps.foreach(_.value.r)
+
+      val regex = ps.head.value.r
+      regex.matches(name)
+      regex.matches(name.toLowerCase(ju.Locale.ROOT))
+      regex.matches(name.toUpperCase(ju.Locale.ROOT))
+
+      assertEquals(ps.head.value, first)
+    }
+  }
+}


### PR DESCRIPTION
Patterns are split on whitespace by the nlp library and then compiled,
so each "word" must be a valid regex.

Fixes: #356