### PR TITLE
(DOCKER) allows to use jbarlow83's official docker image of OCRmyPDF, i.e. use a newer version

### DIFF
--- a/docker/joex-entrypoint.sh
+++ b/docker/joex-entrypoint.sh
@@ -3,4 +3,15 @@
 echo "Starting unoconv listener"
 unoconv -l &
 
+# replace own ocrmypdf with official dockerfile, i.e. newer version
+if [ -S "/var/run/docker.sock" ]; then
+  echo "Found 'docker.sock': Installing Docker and redirecting 'ocrmypdf' command to official dockerfile by jbarlow83"
+  apk --no-cache add docker
+  docker pull jbarlow83/ocrmypdf
+  function ocrmypdf () {
+    docker run jbarlow83/ocrmypdf $@
+  }
+  echo "Using OCRmyPDF v$(ocrmypdf --version)" && echo
+fi
+
 /opt/docspell-joex/bin/docspell-joex "$@"

--- a/docker/joex-entrypoint.sh
+++ b/docker/joex-entrypoint.sh
@@ -7,9 +7,9 @@ unoconv -l &
 if [ -S "/var/run/docker.sock" ]; then
   echo "Found 'docker.sock': Installing Docker and redirecting 'ocrmypdf' command to official dockerfile by jbarlow83"
   apk --no-cache add docker
-  docker pull jbarlow83/ocrmypdf
+  docker pull -q jbarlow83/ocrmypdf:$OCRMYPDF_VERSION
   function ocrmypdf () {
-    docker run jbarlow83/ocrmypdf $@
+    docker run jbarlow83/ocrmypdf:$OCRMYPDF_VERSION $@
   }
   echo "Using OCRmyPDF v$(ocrmypdf --version)" && echo
 fi

--- a/docker/joex-entrypoint.sh
+++ b/docker/joex-entrypoint.sh
@@ -5,13 +5,16 @@ unoconv -l &
 
 # replace own ocrmypdf with official dockerfile, i.e. newer version
 if [ -S "/var/run/docker.sock" ]; then
-  echo "Found 'docker.sock': Installing Docker and redirecting 'ocrmypdf' command to official dockerfile by jbarlow83"
-  apk --no-cache add docker
+  if [ ! -f "/usr/local/bin/ocrmypdf.sh" ]; then
+    echo "Found 'docker.sock': Installing Docker and redirecting 'ocrmypdf' command to official dockerfile by jbarlow83"
+    apk --no-cache add docker
+
+    mv /usr/local/bin/joex-ocrmypdf.sh /usr/local/bin/ocrmypdf
+    chmod ug+x /usr/local/bin/ocrmypdf
+  fi
+
   docker pull -q jbarlow83/ocrmypdf:$OCRMYPDF_VERSION
-  function ocrmypdf () {
-    docker run jbarlow83/ocrmypdf:$OCRMYPDF_VERSION $@
-  }
-  echo "Using OCRmyPDF v$(ocrmypdf --version)" && echo
+  echo "Using OCRmyPDF@Docker v$(ocrmypdf --version)" && echo
 fi
 
 /opt/docspell-joex/bin/docspell-joex "$@"

--- a/docker/joex-ocrmypdf.sh
+++ b/docker/joex-ocrmypdf.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ ! "$1" == "--version" ]; then
+  echo "Using docker image for ocrmypdf (Version: $OCRMYPDF_VERSION)"
+fi
+docker run -v '/tmp/docspell-convert:/tmp/docspell-convert' -e "TZ=$TZ" jbarlow83/ocrmypdf:$OCRMYPDF_VERSION $@

--- a/docker/joex.dockerfile
+++ b/docker/joex.dockerfile
@@ -13,6 +13,7 @@ ENV OCRMYPDF_VERSION=v11.2.1
 
 COPY --from=docspell-base-binaries /opt/docspell-joex /opt/docspell-joex
 COPY joex-entrypoint.sh /opt/joex-entrypoint.sh
+COPY joex-ocrmypdf.sh /usr/local/bin/joex-ocrmypdf.sh
 
 ENTRYPOINT ["/opt/joex-entrypoint.sh"]
 CMD ["/opt/docspell.conf"]

--- a/docker/joex.dockerfile
+++ b/docker/joex.dockerfile
@@ -9,7 +9,7 @@ FROM ${REPO}:base-binaries-${VERSION} as docspell-base-binaries
 
 FROM ${REPO}:joex-base-${VERSION}
 
-ENV OCRMYPDF_VERSION=latest
+ENV OCRMYPDF_VERSION=v11.2.1
 
 COPY --from=docspell-base-binaries /opt/docspell-joex /opt/docspell-joex
 COPY joex-entrypoint.sh /opt/joex-entrypoint.sh

--- a/docker/joex.dockerfile
+++ b/docker/joex.dockerfile
@@ -9,6 +9,8 @@ FROM ${REPO}:base-binaries-${VERSION} as docspell-base-binaries
 
 FROM ${REPO}:joex-base-${VERSION}
 
+ENV OCRMYPDF_VERSION=latest
+
 COPY --from=docspell-base-binaries /opt/docspell-joex /opt/docspell-joex
 COPY joex-entrypoint.sh /opt/joex-entrypoint.sh
 


### PR DESCRIPTION
- if `/var/run/docker.sock` is found in the docker-container, this feature is activated - if not, nothing changes
- usage:
  - mount bind `docker.sock` from host by using `-v` or `volumes:`
  - set environment variable when a certain version of the used docker image is preferred: `OCRMYPDF_VERSION=v11.3.0` or `OCRMYPDF_VERSION=latest`, default (if not set) is `v11.2.1`

addresses #387 