### PR TITLE
(Docker) fixed wrong timezone because of missing tzdata package

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -9,4 +9,3 @@ ENV DB_TYPE=postgresql \
   DB_PASS=dbpass
 
 RUN apk add --no-cache tzdata
-

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -7,3 +7,6 @@ ENV DB_TYPE=postgresql \
   DB_NAME=dbname \
   DB_USER=dbuser \
   DB_PASS=dbpass
+
+RUN apk add --no-cache tzdata
+

--- a/docker/joex-entrypoint.sh
+++ b/docker/joex-entrypoint.sh
@@ -3,4 +3,18 @@
 echo "Starting unoconv listener"
 unoconv -l &
 
+# replace own ocrmypdf with official dockerfile, i.e. newer version
+if [ -S "/var/run/docker.sock" ]; then
+  if [ ! -f "/usr/local/bin/ocrmypdf.sh" ]; then
+    echo "Found 'docker.sock': Installing Docker and redirecting 'ocrmypdf' command to official dockerfile by jbarlow83"
+    apk --no-cache add docker
+
+    mv /usr/local/bin/joex-ocrmypdf.sh /usr/local/bin/ocrmypdf
+    chmod ug+x /usr/local/bin/ocrmypdf
+  fi
+
+  docker pull -q jbarlow83/ocrmypdf:$OCRMYPDF_VERSION
+  echo "Using OCRmyPDF@Docker v$(ocrmypdf --version)" && echo
+fi
+
 /opt/docspell-joex/bin/docspell-joex "$@"

--- a/docker/joex-ocrmypdf.sh
+++ b/docker/joex-ocrmypdf.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+if [ ! "$1" == "--version" ]; then
+  echo "Using docker image for ocrmypdf (Version: $OCRMYPDF_VERSION)"
+fi
+docker run -v '/tmp/docspell-convert:/tmp/docspell-convert' -e "TZ=$TZ" jbarlow83/ocrmypdf:$OCRMYPDF_VERSION $@

--- a/docker/joex.dockerfile
+++ b/docker/joex.dockerfile
@@ -9,8 +9,11 @@ FROM ${REPO}:base-binaries-${VERSION} as docspell-base-binaries
 
 FROM ${REPO}:joex-base-${VERSION}
 
+ENV OCRMYPDF_VERSION=v11.2.1
+
 COPY --from=docspell-base-binaries /opt/docspell-joex /opt/docspell-joex
 COPY joex-entrypoint.sh /opt/joex-entrypoint.sh
+COPY joex-ocrmypdf.sh /usr/local/bin/joex-ocrmypdf.sh
 
 ENTRYPOINT ["/opt/joex-entrypoint.sh"]
 CMD ["/opt/docspell.conf"]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   val StanfordNlpVersion      = "4.0.0"
   val TikaVersion             = "1.24.1"
   val YamuscaVersion          = "0.7.0"
-  val SwaggerUIVersion        = "3.35.2"
+  val SwaggerUIVersion        = "3.36.0"
   val SemanticUIVersion       = "2.4.1"
   val TwelveMonkeysVersion    = "3.6"
   val JQueryVersion           = "3.5.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
   val EmilVersion             = "0.6.3"
   val FastparseVersion        = "2.1.3"
   val FlexmarkVersion         = "0.62.2"
-  val FlywayVersion           = "7.0.4"
+  val FlywayVersion           = "7.1.0"
   val Fs2Version              = "2.4.4"
   val H2Version               = "1.4.200"
   val Http4sVersion           = "0.21.8"


### PR DESCRIPTION
Now the timezone can be set as expected using TZ env variable (has already been set in default `.env` file).

Leads to proper log times (and of course everything else time related as well)