### PR TITLE
Preserve context highlighting from full-text search

### DIFF
--- a/modules/webapp/src/main/elm/Data/Items.elm
+++ b/modules/webapp/src/main/elm/Data/Items.elm
@@ -92,7 +92,7 @@ replaceIn origin replacements =
         replaceItem item =
             case Dict.get item.id newItems of
                 Just ni ->
-                    ni
+                    { ni | highlighting = item.highlighting }
 
                 Nothing ->
                     item


### PR DESCRIPTION
When replacing changed cards the fulltext highlighting should be
preserved from the original item.

Issue: #253 