### PR TITLE
(Docker) fixed wrong timezone because of missing tzdata package

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -7,3 +7,5 @@ ENV DB_TYPE=postgresql \
   DB_NAME=dbname \
   DB_USER=dbuser \
   DB_PASS=dbpass
+
+RUN apk add --no-cache tzdata


### PR DESCRIPTION
Now the timezone can be set as expected using TZ env variable (has already been set in default `.env` file).

Leads to proper log times (and of course everything else time related as well)

replaces #394