### PR TITLE
Introduce fomantic-ui, replacing semantic-ui

### DIFF
--- a/modules/restserver/src/main/scala/docspell/restserver/webapp/TemplateRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/webapp/TemplateRoutes.scala
@@ -138,12 +138,10 @@ object TemplateRoutes {
       IndexData(
         Flags(cfg),
         Seq(
-          "/app/assets" + Webjars.semanticui + "/semantic.min.css",
+          "/app/assets" + Webjars.fomanticslimdefault + "/semantic.min.css",
           s"/app/assets/docspell-webapp/${BuildInfo.version}/docspell.css"
         ),
         Seq(
-          "/app/assets" + Webjars.jquery + "/jquery.min.js",
-          "/app/assets" + Webjars.semanticui + "/semantic.min.js",
           "/app/assets" + Webjars.clipboardjs + "/clipboard.min.js",
           s"/app/assets/docspell-webapp/${BuildInfo.version}/docspell-app.js"
         ),

--- a/modules/webapp/src/main/elm/App/View.elm
+++ b/modules/webapp/src/main/elm/App/View.elm
@@ -207,6 +207,7 @@ loginInfo model =
                         [ classList
                             [ ( "left menu", True )
                             , ( "transition visible", model.navMenuOpen )
+                            , ( "transition hidden", not model.navMenuOpen )
                             ]
                         ]
                         [ menuEntry model

--- a/modules/webapp/src/main/elm/Comp/ItemDetail/Model.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/Model.elm
@@ -83,7 +83,7 @@ type alias Model =
     , selectedFiles : List File
     , completed : Set String
     , errored : Set String
-    , loading : Set String
+    , loading : Dict String Int
     , attachDD : DD.Model String String
     , modalEdit : Maybe Comp.DetailEdit.Model
     , attachRename : Maybe AttachmentRename
@@ -184,7 +184,7 @@ emptyModel =
     , selectedFiles = []
     , completed = Set.empty
     , errored = Set.empty
-    , loading = Set.empty
+    , loading = Dict.empty
     , attachDD = DD.init
     , modalEdit = Nothing
     , attachRename = Nothing

--- a/modules/webapp/src/main/elm/Comp/ItemDetail/View.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/View.elm
@@ -1011,7 +1011,7 @@ isIdle model file =
 
 isLoading : Model -> File -> Bool
 isLoading model file =
-    Set.member (makeFileId file) model.loading
+    Dict.member (makeFileId file) model.loading
 
 
 isCompleted : Model -> File -> Bool

--- a/modules/webapp/src/main/elm/Comp/Progress.elm
+++ b/modules/webapp/src/main/elm/Comp/Progress.elm
@@ -1,0 +1,63 @@
+module Comp.Progress exposing
+    ( smallIndicating
+    , topAttachedIndicating
+    )
+
+import Html exposing (Html, div, text)
+import Html.Attributes exposing (attribute, class, style)
+
+
+smallIndicating : Int -> Html msg
+smallIndicating percent =
+    progress "small indicating active" percent Nothing Nothing
+
+
+topAttachedIndicating : Int -> Html msg
+topAttachedIndicating percent =
+    progress "top attached indicating active" percent Nothing Nothing
+
+
+progress : String -> Int -> Maybe String -> Maybe String -> Html msg
+progress classes percent label barText =
+    if percent <= 0 then
+        div
+            [ class ("ui progress " ++ classes)
+            ]
+            (div [ class "bar" ] (barDiv barText) :: labelDiv label)
+
+    else
+        div
+            [ class ("ui progress " ++ classes)
+            , attribute "data-percent" (String.fromInt percent)
+            ]
+            (div
+                [ class "bar"
+                , style "transition-duration" "300ms"
+                , style "display" "block"
+                , style "width" (String.fromInt percent ++ "%")
+                ]
+                (barDiv barText)
+                :: labelDiv label
+            )
+
+
+labelDiv : Maybe String -> List (Html msg)
+labelDiv label =
+    case label of
+        Just l ->
+            [ div [ class "label" ] [ text l ]
+            ]
+
+        Nothing ->
+            []
+
+
+barDiv : Maybe String -> List (Html msg)
+barDiv barText =
+    case barText of
+        Just t ->
+            [ div [ class "progress" ] [ text t ]
+            ]
+
+        Nothing ->
+            []

--- a/modules/webapp/src/main/elm/Page/Queue/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Queue/Update.elm
@@ -29,9 +29,6 @@ update flags msg model =
 
         StateResp (Ok s) ->
             let
-                progressCmd =
-                    List.map (\job -> Ports.setProgress ( job.id, job.progress )) s.progress
-
                 refresh =
                     if model.pollingInterval <= 0 || model.stopRefresh then
                         Cmd.none
@@ -42,7 +39,7 @@ update flags msg model =
                             , getNewTime
                             ]
             in
-            ( { model | state = s, stopRefresh = False }, Cmd.batch (refresh :: progressCmd) )
+            ( { model | state = s, stopRefresh = False }, refresh )
 
         StateResp (Err err) ->
             ( { model | error = Util.Http.errorToString err }, Cmd.none )

--- a/modules/webapp/src/main/elm/Page/Queue/View.elm
+++ b/modules/webapp/src/main/elm/Page/Queue/View.elm
@@ -2,6 +2,7 @@ module Page.Queue.View exposing (view)
 
 import Api.Model.JobDetail exposing (JobDetail)
 import Api.Model.JobLogEvent exposing (JobLogEvent)
+import Comp.Progress
 import Comp.YesNoDimmer
 import Data.Priority
 import Html exposing (..)
@@ -69,10 +70,7 @@ renderCompleted model =
 renderProgressCard : Model -> JobDetail -> Html Msg
 renderProgressCard model job =
     div [ class "ui fluid card" ]
-        [ div [ id job.id, class "ui top attached indicating progress" ]
-            [ div [ class "bar" ]
-                []
-            ]
+        [ Comp.Progress.topAttachedIndicating job.progress
         , Html.map (DimmerMsg job) (Comp.YesNoDimmer.view2 (model.cancelJobRequest == Just job.id) dimmerSettings model.deleteConfirm)
         , div [ class "content" ]
             [ div [ class "right floated meta" ]

--- a/modules/webapp/src/main/elm/Page/Upload/Data.elm
+++ b/modules/webapp/src/main/elm/Page/Upload/Data.elm
@@ -14,6 +14,7 @@ module Page.Upload.Data exposing
 
 import Api.Model.BasicResult exposing (BasicResult)
 import Comp.Dropzone
+import Dict exposing (Dict)
 import File exposing (File)
 import Http
 import Set exposing (Set)
@@ -26,7 +27,7 @@ type alias Model =
     , files : List File
     , completed : Set String
     , errored : Set String
-    , loading : Set String
+    , loading : Dict String Int
     , dropzone : Comp.Dropzone.Model
     , skipDuplicates : Bool
     }
@@ -55,7 +56,7 @@ emptyModel =
     , files = []
     , completed = Set.empty
     , errored = Set.empty
-    , loading = Set.empty
+    , loading = Dict.empty
     , dropzone = Comp.Dropzone.init dropzoneSettings
     , skipDuplicates = True
     }
@@ -74,7 +75,7 @@ type Msg
 
 isLoading : Model -> File -> Bool
 isLoading model file =
-    Set.member (makeFileId file) model.loading
+    Dict.member (makeFileId file) model.loading
 
 
 isCompleted : Model -> File -> Bool

--- a/modules/webapp/src/main/elm/Page/Upload/View.elm
+++ b/modules/webapp/src/main/elm/Page/Upload/View.elm
@@ -1,6 +1,8 @@
 module Page.Upload.View exposing (view)
 
 import Comp.Dropzone
+import Comp.Progress
+import Dict
 import File exposing (File)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -117,6 +119,20 @@ renderUploads model =
         ]
 
 
+getProgress : Model -> File -> Int
+getProgress model file =
+    let
+        key =
+            if model.singleItem then
+                uploadAllTracker
+
+            else
+                makeFileId file
+    in
+    Dict.get key model.loading
+        |> Maybe.withDefault 0
+
+
 renderFileItem : Model -> Maybe String -> File -> Html Msg
 renderFileItem model mtracker file =
     let
@@ -147,16 +163,7 @@ renderFileItem model mtracker file =
                 [ text size
                 ]
             , div [ class "description" ]
-                [ div
-                    [ classList
-                        [ ( "ui small indicating progress", True )
-                        , ( uploadAllTracker, Util.Maybe.nonEmpty mtracker )
-                        ]
-                    , id (makeFileId file)
-                    ]
-                    [ div [ class "bar" ]
-                        []
-                    ]
+                [ Comp.Progress.smallIndicating (getProgress model file)
                 ]
             ]
         ]

--- a/modules/webapp/src/main/elm/Ports.elm
+++ b/modules/webapp/src/main/elm/Ports.elm
@@ -5,8 +5,6 @@ port module Ports exposing
     , onUiSettingsSaved
     , removeAccount
     , setAccount
-    , setAllProgress
-    , setProgress
     , storeUiSettings
     )
 
@@ -21,12 +19,6 @@ port setAccount : AuthResult -> Cmd msg
 
 
 port removeAccount : () -> Cmd msg
-
-
-port setProgress : ( String, Int ) -> Cmd msg
-
-
-port setAllProgress : ( String, Int ) -> Cmd msg
 
 
 port saveUiSettings : ( AuthResult, StoredUiSettings ) -> Cmd msg

--- a/modules/webapp/src/main/webjar/docspell.js
+++ b/modules/webapp/src/main/webjar/docspell.js
@@ -1,4 +1,24 @@
 /* Docspell JS */
+function forEachIn(obj, fn) {
+    var index = 0;
+    for (var key in obj) {
+        if (obj.hasOwnProperty(key)) {
+            fn(obj[key], key, index++);
+        }
+    }
+}
+
+function extend() {
+    var result = {};
+    for (var i = 0; i < arguments.length; i++) {
+        forEachIn(arguments[i],
+            function(obj, key) {
+                result[key] = obj;
+            });
+    }
+    return result;
+}
+
 
 var elmApp = Elm.Main.init({
     node: document.getElementById("docspell-app"),
@@ -16,21 +36,6 @@ elmApp.ports.removeAccount.subscribe(function() {
     localStorage.removeItem("account");
 });
 
-elmApp.ports.setProgress.subscribe(function(input) {
-    var id = input[0];
-    var percent = input[1];
-    setTimeout(function () {
-        $("#"+id).progress({percent: percent});
-    }, 100);
-});
-
-elmApp.ports.setAllProgress.subscribe(function(input) {
-    var id = input[0];
-    var percent = input[1];
-    setTimeout(function () {
-        $("."+id).progress({percent: percent});
-    }, 100);
-});
 
 elmApp.ports.saveUiSettings.subscribe(function(args) {
     if (Array.isArray(args) && args.length == 2) {
@@ -58,7 +63,7 @@ elmApp.ports.requestUiSettings.subscribe(function(args) {
             var settings = localStorage.getItem(key);
             var data = settings ? JSON.parse(settings) : null;
             if (data && defaults) {
-                $.extend(defaults, data);
+                var defaults = extend(defaults, data);
                 elmApp.ports.receiveUiSettings.send(defaults);
             } else if (defaults) {
                 elmApp.ports.receiveUiSettings.send(defaults);

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -35,7 +35,7 @@ object Dependencies {
   val TikaVersion             = "1.24.1"
   val YamuscaVersion          = "0.7.0"
   val SwaggerUIVersion        = "3.36.1"
-  val SemanticUIVersion       = "2.4.1"
+  val FomanticUIVersion       = "2.8.7-0.2"
   val TwelveMonkeysVersion    = "3.6"
   val JQueryVersion           = "3.5.1"
   val ViewerJSVersion         = "0.5.8"
@@ -251,11 +251,10 @@ object Dependencies {
   val betterMonadicFor    = "com.olegpy"    %% "better-monadic-for" % BetterMonadicForVersion
 
   val webjars = Seq(
-    "org.webjars" % "swagger-ui"   % SwaggerUIVersion,
-    "org.webjars" % "Semantic-UI"  % SemanticUIVersion,
-    "org.webjars" % "jquery"       % JQueryVersion,
-    "org.webjars" % "viewerjs"     % ViewerJSVersion,
-    "org.webjars" % "clipboard.js" % ClipboardJsVersion
+    "org.webjars"      % "swagger-ui"            % SwaggerUIVersion,
+    "com.github.eikek" % "fomantic-slim-default" % FomanticUIVersion,
+    "org.webjars"      % "viewerjs"              % ViewerJSVersion,
+    "org.webjars"      % "clipboard.js"          % ClipboardJsVersion
   )
 
   val icu4j = Seq(


### PR DESCRIPTION
Replaced semantic-ui with the drop-in replacement fomantic-ui [0]
which is a maintained fork. The fomantic-ui used here is a custom
build [1] of the less-version _without_ google-fonts (css-only). The
javascript part of fomantic-ui is not used, and also jquery could be
dropped now.

[0] https://fomantic-ui.com
[1] https://github.com/eikek/fomantic-slim-default

Closes: #349