### PR TITLE
Show concerning/correspond person exclusively in dropdowns

### DIFF
--- a/modules/webapp/src/main/elm/Comp/ItemDetail/EditMenu.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/EditMenu.elm
@@ -15,6 +15,7 @@ import Api.Model.FolderItem exposing (FolderItem)
 import Api.Model.FolderList exposing (FolderList)
 import Api.Model.IdName exposing (IdName)
 import Api.Model.ItemProposals exposing (ItemProposals)
+import Api.Model.PersonList exposing (PersonList)
 import Api.Model.ReferenceList exposing (ReferenceList)
 import Api.Model.Tag exposing (Tag)
 import Api.Model.TagList exposing (TagList)
@@ -102,7 +103,7 @@ type Msg
     | ConcEquipMsg (Comp.Dropdown.Msg IdName)
     | GetTagsResp (Result Http.Error TagList)
     | GetOrgResp (Result Http.Error ReferenceList)
-    | GetPersonResp (Result Http.Error ReferenceList)
+    | GetPersonResp (Result Http.Error PersonList)
     | GetEquipResp (Result Http.Error EquipmentList)
     | GetFolderResp (Result Http.Error FolderList)
     | CustomFieldMsg Comp.CustomFieldMultiInput.Msg
@@ -172,7 +173,7 @@ loadModel flags =
     Cmd.batch
         [ Api.getTags flags "" GetTagsResp
         , Api.getOrgLight flags GetOrgResp
-        , Api.getPersonsLight flags GetPersonResp
+        , Api.getPersons flags "" GetPersonResp
         , Api.getEquipments flags "" GetEquipResp
         , Api.getFolders flags "" False GetFolderResp
         , Cmd.map CustomFieldMsg (Comp.CustomFieldMultiInput.initCmd flags)
@@ -422,14 +423,20 @@ update flags msg model =
 
         GetPersonResp (Ok ps) ->
             let
-                opts =
-                    Comp.Dropdown.SetOptions ps.items
+                ( conc, corr ) =
+                    List.partition .concerning ps.items
+
+                concRefs =
+                    List.map (\e -> IdName e.id e.name) conc
+
+                corrRefs =
+                    List.map (\e -> IdName e.id e.name) corr
 
                 res1 =
-                    update flags (CorrPersonMsg opts) model
+                    update flags (CorrPersonMsg (Comp.Dropdown.SetOptions corrRefs)) model
 
                 res2 =
-                    update flags (ConcPersonMsg opts) res1.model
+                    update flags (ConcPersonMsg (Comp.Dropdown.SetOptions concRefs)) res1.model
             in
             res2
 

--- a/modules/webapp/src/main/elm/Comp/ItemDetail/Model.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/Model.elm
@@ -20,6 +20,7 @@ import Api.Model.FolderList exposing (FolderList)
 import Api.Model.IdName exposing (IdName)
 import Api.Model.ItemDetail exposing (ItemDetail)
 import Api.Model.ItemProposals exposing (ItemProposals)
+import Api.Model.PersonList exposing (PersonList)
 import Api.Model.ReferenceList exposing (ReferenceList)
 import Api.Model.SentMails exposing (SentMails)
 import Api.Model.Tag exposing (Tag)
@@ -221,7 +222,7 @@ type Msg
     | ConcEquipMsg (Comp.Dropdown.Msg IdName)
     | GetTagsResp (Result Http.Error TagList)
     | GetOrgResp (Result Http.Error ReferenceList)
-    | GetPersonResp (Result Http.Error ReferenceList)
+    | GetPersonResp (Result Http.Error PersonList)
     | GetEquipResp (Result Http.Error EquipmentList)
     | SetName String
     | SetNotes String

--- a/modules/webapp/src/main/elm/Comp/ItemDetail/Update.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/Update.elm
@@ -606,14 +606,30 @@ update key flags inav settings msg model =
 
         GetPersonResp (Ok ps) ->
             let
-                opts =
-                    Comp.Dropdown.SetOptions ps.items
+                ( conc, corr ) =
+                    List.partition .concerning ps.items
+
+                concRefs =
+                    List.map (\e -> IdName e.id e.name) conc
+
+                corrRefs =
+                    List.map (\e -> IdName e.id e.name) corr
 
                 res1 =
-                    update key flags inav settings (CorrPersonMsg opts) model
+                    update key
+                        flags
+                        inav
+                        settings
+                        (CorrPersonMsg (Comp.Dropdown.SetOptions corrRefs))
+                        model
 
                 res2 =
-                    update key flags inav settings (ConcPersonMsg opts) res1.model
+                    update key
+                        flags
+                        inav
+                        settings
+                        (ConcPersonMsg (Comp.Dropdown.SetOptions concRefs))
+                        res1.model
             in
             { model = res2.model
             , cmd = Cmd.batch [ res1.cmd, res2.cmd ]
@@ -1410,7 +1426,7 @@ getOptions flags =
     Cmd.batch
         [ Api.getTags flags "" GetTagsResp
         , Api.getOrgLight flags GetOrgResp
-        , Api.getPersonsLight flags GetPersonResp
+        , Api.getPersons flags "" GetPersonResp
         , Api.getEquipments flags "" GetEquipResp
         , Api.getFolders flags "" False GetFolderResp
         ]

--- a/modules/webapp/src/main/elm/Comp/SearchMenu.elm
+++ b/modules/webapp/src/main/elm/Comp/SearchMenu.elm
@@ -17,6 +17,7 @@ import Api.Model.FolderItem exposing (FolderItem)
 import Api.Model.FolderList exposing (FolderList)
 import Api.Model.IdName exposing (IdName)
 import Api.Model.ItemSearch exposing (ItemSearch)
+import Api.Model.PersonList exposing (PersonList)
 import Api.Model.ReferenceList exposing (ReferenceList)
 import Api.Model.TagCloud exposing (TagCloud)
 import Comp.CustomFieldMultiInput
@@ -256,7 +257,7 @@ type Msg
     | GetTagsResp (Result Http.Error TagCloud)
     | GetOrgResp (Result Http.Error ReferenceList)
     | GetEquipResp (Result Http.Error EquipmentList)
-    | GetPersonResp (Result Http.Error ReferenceList)
+    | GetPersonResp (Result Http.Error PersonList)
     | SetName String
     | SetAllName String
     | SetFulltext String
@@ -341,7 +342,7 @@ updateDrop ddm flags settings msg model =
                     [ Api.getTagCloud flags GetTagsResp
                     , Api.getOrgLight flags GetOrgResp
                     , Api.getEquipments flags "" GetEquipResp
-                    , Api.getPersonsLight flags GetPersonResp
+                    , Api.getPersons flags "" GetPersonResp
                     , Api.getFolders flags "" False GetFolderResp
                     , Cmd.map CustomFieldMsg (Comp.CustomFieldMultiInput.initCmd flags)
                     , cdp
@@ -441,14 +442,28 @@ updateDrop ddm flags settings msg model =
 
         GetPersonResp (Ok ps) ->
             let
-                opts =
-                    Comp.Dropdown.SetOptions ps.items
+                ( conc, corr ) =
+                    List.partition .concerning ps.items
+
+                concRefs =
+                    List.map (\e -> IdName e.id e.name) conc
+
+                corrRefs =
+                    List.map (\e -> IdName e.id e.name) corr
 
                 next1 =
-                    updateDrop ddm flags settings (CorrPersonMsg opts) model
+                    updateDrop ddm
+                        flags
+                        settings
+                        (CorrPersonMsg (Comp.Dropdown.SetOptions corrRefs))
+                        model
 
                 next2 =
-                    updateDrop next1.dragDrop.model flags settings (ConcPersonMsg opts) next1.model
+                    updateDrop next1.dragDrop.model
+                        flags
+                        settings
+                        (ConcPersonMsg (Comp.Dropdown.SetOptions concRefs))
+                        next1.model
             in
             next2
 


### PR DESCRIPTION
Now a person that is not marked as "concerning only" is treated as
"correspondent only". The options of all dropdown fields are now
restricted to those subsets.

Closes: #332