### PR TITLE
DateFind could not handle dates in January

### DIFF
--- a/modules/analysis/src/main/scala/docspell/analysis/date/DateFind.scala
+++ b/modules/analysis/src/main/scala/docspell/analysis/date/DateFind.scala
@@ -76,7 +76,7 @@ object DateFind {
 
     def readMonth: Reader[Int] =
       Reader.readFirst(w =>
-        Some(months.indexWhere(_.contains(w.value))).filter(_ > 0).map(_ + 1)
+        Some(months.indexWhere(_.contains(w.value))).filter(_ >= 0).map(_ + 1)
       )
 
     def readDay: Reader[Int] =


### PR DESCRIPTION
Due to an off-by-one issue, dates in January could not be detected. This PR aims at fixing this. Since January is at index 0, the filter needs to check for > -1 (or >= 0).