### PR TITLE
Allow scaling joex with `docker-compose up --scale`

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,6 @@ services:
 
   joex:
     image: eikek0/docspell:joex-LATEST
-    container_name: docspell-joex
     restart: unless-stopped
     env_file: ./.env
     ports:

--- a/docker/docspell.conf
+++ b/docker/docspell.conf
@@ -27,7 +27,8 @@ docspell.server {
 }
 
 docspell.joex {
-  base-url = "http://joex:7878"
+  app-id = "joex-"${HOSTNAME}
+  base-url = "http://"${HOSTNAME}":7878"
   bind {
     address = "0.0.0.0"
   }


### PR DESCRIPTION
Container name can't be hard coded and each joex instance needs a unique
name. Since Docker always sets the `HOSTNAME` variable and these are
unique, we can just interpolate the hostname into the joex app
identifier, to avoid creating multiple config files.