### PR TITLE
Fix permission of scripts in base-binaries

### DIFF
--- a/docker/base-binaries.dockerfile
+++ b/docker/base-binaries.dockerfile
@@ -38,7 +38,7 @@ RUN find "/src/docspell/modules/restserver/target/universal/" -name "docspell-re
 RUN mv /opt/docspell-restserver-* /opt/docspell-restserver
 RUN find "/src/docspell/tools/target/" -name "docspell-tools-*.zip" -exec unzip {} -d "/opt/" \;
 RUN mv /opt/docspell-tools-* /opt/docspell-tools
-RUN chmod 755 /opt/docspell-tools/*.sh
+RUN chmod 755 /opt/docspell-tools/**/*.sh
 
 COPY ./docker/docspell.conf /opt/docspell.conf
 


### PR DESCRIPTION
Due to the shell files being moved in the subdirectories, the `chmod` no longer applies to them. This will result in the `consumedir` container failing, as the entry point is not executable.

This pull request fixes this issue.

Include shell files in subdirectory of `/opt/docspell-tools/` via `**/*.sh`.

As there is no CLA here: Code released under the original license or any other license chosen for the repo now and/or in the future.