### PR TITLE
Fix CONSUMEDIR_DELETE being ignored

### DIFF
--- a/docker/consumedir-entrypoint.sh
+++ b/docker/consumedir-entrypoint.sh
@@ -59,6 +59,10 @@ if [ -z "${CONSUMEDIR_ARGS}" ]; then
 		CONSUMEDIR_ARGS="$CONSUMEDIR_ARGS -v"
 	fi
 
+	if [ "${CONSUMEDIR_DELETE-n}" = "y" ]; then
+		CONSUMEDIR_ARGS="$CONSUMEDIR_ARGS -d"
+	fi
+
 	if [ "${CONSUMEDIR_UNIQUE-n}" = "y" ]; then
 		CONSUMEDIR_ARGS="$CONSUMEDIR_ARGS -m"
 	fi


### PR DESCRIPTION
I just noticed that CONSUMEDIR_DELETE  wasn't handled yet. This fixes it.