### PR TITLE
Make detecting version more reliable

### DIFF
--- a/docker/dev-build-images.sh
+++ b/docker/dev-build-images.sh
@@ -5,12 +5,8 @@ if [ $# -eq 1 ]; then
   REPO=$1
 fi
 
-SBT_VERSION=$(grep sbt.version ../project/build.properties)
-SBT_VERSION=${SBT_VERSION:12:99}
-
-TMP_VERSION=$(cat ../version.sbt)
-TMP_VERSION=${TMP_VERSION:25:99}
-VERSION=${TMP_VERSION%\"}
+SBT_VERSION=$(grep sbt.version ../project/build.properties|cut -d'=' -f2|xargs)
+VERSION=$(cat ../version.sbt | cut -d'=' -f2 | tr -d '"'|xargs)
 
 if [[ $VERSION == *"SNAPSHOT" ]]; then
   VERSION=SNAPSHOT

--- a/docker/dev-push-images.sh
+++ b/docker/dev-push-images.sh
@@ -5,9 +5,7 @@ if [ $# -eq 1 ]; then
   REPO=$1
 fi
 
-TMP_VERSION=$(cat ../version.sbt)
-TMP_VERSION=${TMP_VERSION:25:99}
-VERSION=${TMP_VERSION%\"}
+VERSION=$(cat ../version.sbt | cut -d'=' -f2 | tr -d '"'|xargs)
 
 if [[ $VERSION == *"SNAPSHOT" ]]; then
   VERSION=SNAPSHOT

--- a/docker/hooks/build
+++ b/docker/hooks/build
@@ -15,9 +15,7 @@ echo "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 # verify that version.sbt and tag match for non-snapshot (ENV variable DOCKER_VERIFY_TAG must be set to 1)
 if [ $DOCKER_VERIFY_TAG -eq 1 ] && [[ "$DOCKER_TAG" != *"-SNAPSHOT" ]]; then
   echo validating version number...
-  TMP_VERSION=$(cat ../version.sbt)
-  TMP_VERSION=${TMP_VERSION:25:99}
-  VERSION=${TMP_VERSION%\"}
+  VERSION=$(cat ../version.sbt | cut -d'=' -f2 | tr -d '"'|xargs)
   if [ "$DOCKER_TAG" != "base-v$VERSION" ]; then
     echo "version number mismatch (Docker/Tag: $DOCKER_TAG, Project: $VERSION), aborting!"
     exit 1


### PR DESCRIPTION
The docker bash scripts try to get the version from sbt, without
calling sbt but reading the files. This was relying on a specific
position. It is now a bit more robust.