### PR TITLE
Make consumedir-cleaner able to run on Windows

### DIFF
--- a/tools/consumedir-cleaner/consumedir-cleaner.sh
+++ b/tools/consumedir-cleaner/consumedir-cleaner.sh
@@ -149,8 +149,7 @@ do
       rm "$tmp_filepath"
     else
       created=$(echo $curl_result | $JQ_CMD -r ".items[0].created")
-      cur_dir="$ds_archive_path/$(date -d @$(echo "($created+500)/1000" | bc) +%Y-%m
-)"
+      cur_dir="$ds_archive_path/$(date -d @$(expr \( $created + 500 \) / 1000) +%Y-%m)"
       echo "... moving to archive by month added ('$cur_dir')"
       mkdir -p "$cur_dir"
       mv "$tmp_filepath" "$cur_dir/"


### PR DESCRIPTION
Since `bc` isn't available for Windows I changed it to use `expr`.