### PR TITLE
Don't use jq to clean whitespace/quotes

### DIFF
--- a/tools/download-files/download-files.sh
+++ b/tools/download-files/download-files.sh
@@ -150,7 +150,7 @@ downloadAttachment() {
         DL_URL="$ATTACH_URL/$attachId"
 
         checksum1=$("$CURL_CMD" -s -I -H "X-Docspell-Auth: $auth_token" "$DL_URL" | \
-                        grep -i 'etag' | cut -d' ' -f2 | "$JQ_CMD" -r)
+                        grep -i 'etag' | cut -d' ' -f2 | xargs | tr -d '\r')
         "$CURL_CMD" -s -o "$attachOut" -H "X-Docspell-Auth: $auth_token" "$DL_URL"
         checksum2=$(sha256sum "$attachOut" | cut -d' ' -f1 | xargs)
         if [ "$checksum1" == "$checksum2" ]; then

--- a/tools/export-files/export-files.sh
+++ b/tools/export-files/export-files.sh
@@ -178,7 +178,7 @@ downloadAttachment() {
         fi
 
         checksum1=$("$CURL_CMD" -s -I -H "X-Docspell-Auth: $auth_token" "$ATTACH_URL/$attachId/original" | \
-                        grep -i 'etag' | cut -d' ' -f2 | "$JQ_CMD" -r)
+                        grep -i 'etag' | cut -d':' -f2 | xargs | tr -d '\r')
         "$CURL_CMD" -s -o "$attachOut" -H "X-Docspell-Auth: $auth_token" "$ATTACH_URL/$attachId/original"
         checksum2=$(sha256sum "$attachOut" | cut -d' ' -f1 | xargs)
         if [ "$checksum1" == "$checksum2" ]; then
@@ -212,15 +212,13 @@ downloadItem() {
             errout " - Removing metadata.json as requested"
             rm -f "$out/metadata.json"
         fi
-        echo $itemData | "$JQ_CMD" > "$out/metadata.json"
+        echo $itemData > "$out/metadata.json"
     fi
-
     while read attachId attachName; do
         attachOut="$out/$attachName"
         checkLogin
         downloadAttachment "$attachId"
     done < <(echo $itemData | "$JQ_CMD" -r '.sources[] | [.id,.name] | join(" ")')
-
 }
 
 login


### PR DESCRIPTION
It seems that older jq versions choke on some output from curl inside
these scripts. But I couldn't reproduce this on the cmdline; so not
really sure what's going on, suspecting some settings in the bash
script. Tested this with jq-1.5 and jq-1.6, both worked. But since
`xargs` also trims a string from quotes and whitespace, it can be used
instead of jq in these places.