### PR TITLE
Don't toggle dropdown on space

### DIFF
--- a/modules/webapp/src/main/elm/Comp/Dropdown.elm
+++ b/modules/webapp/src/main/elm/Comp/Dropdown.elm
@@ -359,7 +359,7 @@ update msg model =
 
                 Just Util.Html.ESC ->
                     if model.menuOpen then
-                        ( model, Cmd.none )
+                        update ToggleMenu model
 
                     else
                         case model.selected of
@@ -374,7 +374,11 @@ update msg model =
                                 ( model, Cmd.none )
 
                 Just Util.Html.Space ->
-                    update ToggleMenu model
+                    if model.menuOpen then
+                        ( model, Cmd.none )
+
+                    else
+                        update ToggleMenu model
 
                 Just Util.Html.Enter ->
                     let


### PR DESCRIPTION
Closing the dropdown menu is now possible with ESC. Space will only
open the dropdown, but not close it. So now it's possible to type a
space into the search field.

Fixes: #863