### PR TITLE
Update language dropdown for new data

### DIFF
--- a/modules/webapp/src/main/elm/Comp/SourceForm.elm
+++ b/modules/webapp/src/main/elm/Comp/SourceForm.elm
@@ -155,6 +155,7 @@ update flags msg model =
                         , enabled = t.source.enabled
                         , folder = t.source.folder
                         , fileFilter = t.source.fileFilter
+                        , language = t.source.language
                     }
 
                 newModel =
@@ -168,6 +169,7 @@ update flags msg model =
                         , enabled = t.source.enabled
                         , folderId = t.source.folder
                         , fileFilter = t.source.fileFilter
+                        , language = t.source.language
                     }
 
                 mkIdName id =
@@ -189,12 +191,21 @@ update flags msg model =
                         Nothing ->
                             []
 
+                langSel =
+                    case Maybe.andThen Data.Language.fromString t.source.language of
+                        Just lang ->
+                            [ lang ]
+
+                        Nothing ->
+                            []
+
                 tags =
                     Comp.Dropdown.SetSelection t.tags.items
             in
             Util.Update.andThen1
                 [ update flags (FolderDropdownMsg (Comp.Dropdown.SetSelection sel))
                 , update flags (TagDropdownMsg tags)
+                , update flags (LanguageMsg (Comp.Dropdown.SetSelection langSel))
                 ]
                 newModel
 


### PR DESCRIPTION
When receiving a new value to display in the form, the language
dropdown was not initialized with the corresponding value.

Fixes: #877 