### PR TITLE
Compile the small number of java source files to java 8 target

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ val sharedSettings = Seq(
     "-Wvalue-discard",
     "-Wnumeric-widen"
   ),
+  javacOptions ++= Seq("-target", "1.8", "-source", "1.8"),
   LocalRootProject / toolsPackage := {
     val v      = version.value
     val logger = streams.value.log


### PR DESCRIPTION
Since scala also produces class files version 52, the few java files
should also be compiled into this format.