### PR TITLE
Remove a deleted item from search results

### DIFF
--- a/modules/webapp/src/main/elm/App/Update.elm
+++ b/modules/webapp/src/main/elm/App/Update.elm
@@ -331,10 +331,18 @@ updateItemDetail lmsg model =
 
         ( hm, hc, hs ) =
             updateHome (Page.Home.Data.SetLinkTarget result.linkTarget) model_
+
+        ( hm1, hc1, hs1 ) =
+            case result.removedItem of
+                Just removedId ->
+                    updateHome (Page.Home.Data.RemoveItem removedId) hm
+
+                Nothing ->
+                    ( hm, hc, hs )
     in
-    ( hm
-    , Cmd.batch [ Cmd.map ItemDetailMsg result.cmd, hc ]
-    , Sub.batch [ Sub.map ItemDetailMsg result.sub, hs ]
+    ( hm1
+    , Cmd.batch [ Cmd.map ItemDetailMsg result.cmd, hc, hc1 ]
+    , Sub.batch [ Sub.map ItemDetailMsg result.sub, hs, hs1 ]
     )
 
 

--- a/modules/webapp/src/main/elm/Comp/ItemCardList.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemCardList.elm
@@ -46,6 +46,7 @@ type Msg
     = SetResults ItemLightList
     | AddResults ItemLightList
     | ItemCardMsg ItemLight Comp.ItemCard.Msg
+    | RemoveItem String
 
 
 init : Model
@@ -145,6 +146,13 @@ updateDrag dm _ msg model =
                 result.selection
                 result.linkTarget
 
+        RemoveItem id ->
+            UpdateResult { model | results = removeItemById id model.results }
+                Cmd.none
+                dm
+                Data.ItemSelection.Inactive
+                Comp.LinkTarget.LinkNone
+
 
 
 --- View2
@@ -232,3 +240,15 @@ isMultiSelectMode cfg =
 
         Data.ItemSelection.Inactive ->
             False
+
+
+removeItemById : String -> ItemLightList -> ItemLightList
+removeItemById id list =
+    let
+        filterItem item =
+            item.id /= id
+
+        filterGroup group =
+            { group | items = List.filter filterItem group.items }
+    in
+    { list | groups = List.map filterGroup list.groups }

--- a/modules/webapp/src/main/elm/Comp/ItemDetail/Model.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/Model.elm
@@ -276,7 +276,7 @@ type Msg
     | ItemModalCancelled
     | RequestDelete
     | SaveResp (Result Http.Error BasicResult)
-    | DeleteResp (Result Http.Error BasicResult)
+    | DeleteResp String (Result Http.Error BasicResult)
     | GetItemResp (Result Http.Error ItemDetail)
     | GetProposalResp (Result Http.Error ItemProposals)
     | RemoveDueDate
@@ -352,22 +352,23 @@ type alias UpdateResult =
     , cmd : Cmd Msg
     , sub : Sub Msg
     , linkTarget : LinkTarget
+    , removedItem : Maybe String
     }
 
 
 resultModel : Model -> UpdateResult
 resultModel model =
-    UpdateResult model Cmd.none Sub.none Comp.LinkTarget.LinkNone
+    UpdateResult model Cmd.none Sub.none Comp.LinkTarget.LinkNone Nothing
 
 
 resultModelCmd : ( Model, Cmd Msg ) -> UpdateResult
 resultModelCmd ( model, cmd ) =
-    UpdateResult model cmd Sub.none Comp.LinkTarget.LinkNone
+    UpdateResult model cmd Sub.none Comp.LinkTarget.LinkNone Nothing
 
 
 resultModelCmdSub : ( Model, Cmd Msg, Sub Msg ) -> UpdateResult
 resultModelCmdSub ( model, cmd, sub ) =
-    UpdateResult model cmd sub Comp.LinkTarget.LinkNone
+    UpdateResult model cmd sub Comp.LinkTarget.LinkNone Nothing
 
 
 personMatchesOrg : Model -> Bool

--- a/modules/webapp/src/main/elm/Page/Home/Data.elm
+++ b/modules/webapp/src/main/elm/Page/Home/Data.elm
@@ -201,6 +201,7 @@ type Msg
     | RequestReprocessSelected
     | ReprocessSelectedConfirmed
     | ClientSettingsSaveResp UiSettings (Result Http.Error BasicResult)
+    | RemoveItem String
 
 
 type SearchType

--- a/modules/webapp/src/main/elm/Page/Home/Update.elm
+++ b/modules/webapp/src/main/elm/Page/Home/Update.elm
@@ -652,6 +652,9 @@ update mId key flags settings msg model =
         KeyUpPowerSearchbarMsg _ ->
             withSub ( model, Cmd.none )
 
+        RemoveItem id ->
+            update mId key flags settings (ItemCardListMsg (Comp.ItemCardList.RemoveItem id)) model
+
 
 
 --- Helpers

--- a/modules/webapp/src/main/elm/Page/ItemDetail/Data.elm
+++ b/modules/webapp/src/main/elm/Page/ItemDetail/Data.elm
@@ -44,4 +44,5 @@ type alias UpdateResult =
     , cmd : Cmd Msg
     , sub : Sub Msg
     , linkTarget : LinkTarget
+    , removedItem : Maybe String
     }

--- a/modules/webapp/src/main/elm/Page/ItemDetail/Update.elm
+++ b/modules/webapp/src/main/elm/Page/ItemDetail/Update.elm
@@ -46,6 +46,7 @@ update key flags inav settings msg model =
                     ]
             , sub = Sub.map ItemDetailMsg result.sub
             , linkTarget = result.linkTarget
+            , removedItem = result.removedItem
             }
 
         ItemDetailMsg lmsg ->
@@ -65,6 +66,7 @@ update key flags inav settings msg model =
             , cmd = Cmd.batch [ pageSwitch, Cmd.map ItemDetailMsg result.cmd ]
             , sub = Sub.map ItemDetailMsg result.sub
             , linkTarget = result.linkTarget
+            , removedItem = result.removedItem
             }
 
         ItemResp (Ok item) ->
@@ -75,10 +77,10 @@ update key flags inav settings msg model =
             update key flags inav settings (ItemDetailMsg lmsg) model
 
         ItemResp (Err _) ->
-            UpdateResult model Cmd.none Sub.none Comp.LinkTarget.LinkNone
+            UpdateResult model Cmd.none Sub.none Comp.LinkTarget.LinkNone Nothing
 
         ScrollResult _ ->
-            UpdateResult model Cmd.none Sub.none Comp.LinkTarget.LinkNone
+            UpdateResult model Cmd.none Sub.none Comp.LinkTarget.LinkNone Nothing
 
         UiSettingsUpdated ->
             let


### PR DESCRIPTION
When an item is deleted in detail view, the results must be updated to
reflect the new state. The results are now changed by removing the
corresponding item.

Fixes: #920