### PR TITLE
Use a minimum age of items to remove

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -242,6 +242,10 @@ val openapiScalaSettings = Seq(
         field =>
           field
             .copy(typeDef = TypeDef("SearchMode", Imports("docspell.common.SearchMode")))
+      case "duration" =>
+        field =>
+          field
+            .copy(typeDef = TypeDef("Duration", Imports("docspell.common.Duration")))
     }))
 )
 

--- a/modules/backend/src/main/scala/docspell/backend/ops/OItemSearch.scala
+++ b/modules/backend/src/main/scala/docspell/backend/ops/OItemSearch.scala
@@ -23,7 +23,7 @@ import doobie.implicits._
 trait OItemSearch[F[_]] {
   def findItem(id: Ident, collective: Ident): F[Option[ItemData]]
 
-  def findDeleted(collective: Ident, limit: Int): F[Vector[RItem]]
+  def findDeleted(collective: Ident, maxUpdate: Timestamp, limit: Int): F[Vector[RItem]]
 
   def findItems(maxNoteLen: Int)(q: Query, batch: Batch): F[Vector[ListItem]]
 
@@ -147,9 +147,13 @@ object OItemSearch {
               .toVector
           }
 
-      def findDeleted(collective: Ident, limit: Int): F[Vector[RItem]] =
+      def findDeleted(
+          collective: Ident,
+          maxUpdate: Timestamp,
+          limit: Int
+      ): F[Vector[RItem]] =
         store
-          .transact(RItem.findDeleted(collective, limit))
+          .transact(RItem.findDeleted(collective, maxUpdate, limit))
           .take(limit.toLong)
           .compile
           .toVector

--- a/modules/common/src/main/scala/docspell/common/EmptyTrashArgs.scala
+++ b/modules/common/src/main/scala/docspell/common/EmptyTrashArgs.scala
@@ -18,11 +18,12 @@ import io.circe.generic.semiauto._
   * items. These are items with state `ItemState.Deleted`.
   */
 case class EmptyTrashArgs(
-    collective: Ident
+    collective: Ident,
+    minAge: Duration
 ) {
 
   def makeSubject: String =
-    "Empty trash"
+    s"Empty Trash: Remove older than ${minAge.toJava}"
 
 }
 

--- a/modules/joex/src/main/scala/docspell/joex/JoexAppImpl.scala
+++ b/modules/joex/src/main/scala/docspell/joex/JoexAppImpl.scala
@@ -87,9 +87,11 @@ final class JoexAppImpl[F[_]: Async](
   private def scheduleEmptyTrashTasks: F[Unit] =
     store
       .transact(
-        REmptyTrashSetting.findForAllCollectives(EmptyTrashArgs.defaultSchedule, 50)
+        REmptyTrashSetting.findForAllCollectives(OCollective.EmptyTrash.default, 50)
       )
-      .evalMap(es => EmptyTrashTask.periodicTask(es.cid, es.schedule))
+      .evalMap(es =>
+        EmptyTrashTask.periodicTask(EmptyTrashArgs(es.cid, es.minAge), es.schedule)
+      )
       .evalMap(pstore.insert)
       .compile
       .drain

--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -1149,6 +1149,11 @@ paths:
         The request is empty, settings are used from the collective.
       security:
         - authTokenHeader: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmptyTrashSetting"
       responses:
         200:
           description: Ok
@@ -5267,7 +5272,7 @@ components:
         - language
         - integrationEnabled
         - classifier
-        - emptyTrashSchedule
+        - emptyTrash
       properties:
         language:
           type: string
@@ -5277,11 +5282,24 @@ components:
           description: |
             Whether the collective has the integration endpoint
             enabled.
-        emptyTrashSchedule:
-          type: string
-          format: calevent
         classifier:
           $ref: "#/components/schemas/ClassifierSetting"
+        emptyTrash:
+          $ref: "#/components/schemas/EmptyTrashSetting"
+
+    EmptyTrashSetting:
+      description: |
+        Settings for clearing the trash of items.
+      required:
+        - schedule
+        - minAge
+      properties:
+        schedule:
+          type: string
+          format: calevent
+        minAge:
+          type: integer
+          format: duration
 
     ClassifierSetting:
       description: |

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/NotifyDueItemsRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/NotifyDueItemsRoutes.scala
@@ -49,7 +49,7 @@ object NotifyDueItemsRoutes {
           newId <- Ident.randomId[F]
           task  <- makeTask(newId, getBaseUrl(cfg, req), user.account, data)
           res <-
-            ut.executeNow(UserTaskScope(user.account), task)
+            ut.executeNow(UserTaskScope(user.account), None, task)
               .attempt
               .map(Conversions.basicResult(_, "Submitted successfully."))
           resp <- Ok(res)
@@ -69,7 +69,7 @@ object NotifyDueItemsRoutes {
           for {
             task <- makeTask(data.id, getBaseUrl(cfg, req), user.account, data)
             res <-
-              ut.submitNotifyDueItems(UserTaskScope(user.account), task)
+              ut.submitNotifyDueItems(UserTaskScope(user.account), None, task)
                 .attempt
                 .map(Conversions.basicResult(_, "Saved successfully"))
             resp <- Ok(res)
@@ -87,7 +87,7 @@ object NotifyDueItemsRoutes {
           newId <- Ident.randomId[F]
           task  <- makeTask(newId, getBaseUrl(cfg, req), user.account, data)
           res <-
-            ut.submitNotifyDueItems(UserTaskScope(user.account), task)
+            ut.submitNotifyDueItems(UserTaskScope(user.account), None, task)
               .attempt
               .map(Conversions.basicResult(_, "Saved successfully."))
           resp <- Ok(res)

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/ScanMailboxRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/ScanMailboxRoutes.scala
@@ -46,7 +46,7 @@ object ScanMailboxRoutes {
           newId <- Ident.randomId[F]
           task  <- makeTask(newId, user.account, data)
           res <-
-            ut.executeNow(UserTaskScope(user.account), task)
+            ut.executeNow(UserTaskScope(user.account), None, task)
               .attempt
               .map(Conversions.basicResult(_, "Submitted successfully."))
           resp <- Ok(res)
@@ -66,7 +66,7 @@ object ScanMailboxRoutes {
           for {
             task <- makeTask(data.id, user.account, data)
             res <-
-              ut.submitScanMailbox(UserTaskScope(user.account), task)
+              ut.submitScanMailbox(UserTaskScope(user.account), None, task)
                 .attempt
                 .map(Conversions.basicResult(_, "Saved successfully."))
             resp <- Ok(res)
@@ -84,7 +84,7 @@ object ScanMailboxRoutes {
           newId <- Ident.randomId[F]
           task  <- makeTask(newId, user.account, data)
           res <-
-            ut.submitScanMailbox(UserTaskScope(user.account), task)
+            ut.submitScanMailbox(UserTaskScope(user.account), None, task)
               .attempt
               .map(Conversions.basicResult(_, "Saved successfully."))
           resp <- Ok(res)

--- a/modules/store/src/main/resources/db/migration/h2/V1.25.2__add_trash_min_age.sql
+++ b/modules/store/src/main/resources/db/migration/h2/V1.25.2__add_trash_min_age.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "empty_trash_setting"
+ADD COLUMN "min_age" bigint;
+
+UPDATE "empty_trash_setting"
+SET "min_age" = 604800000;
+
+ALTER TABLE "empty_trash_setting"
+ALTER COLUMN "min_age" SET NOT NULL;

--- a/modules/store/src/main/resources/db/migration/mariadb/V1.25.2__add_trash_min_age.sql
+++ b/modules/store/src/main/resources/db/migration/mariadb/V1.25.2__add_trash_min_age.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `empty_trash_setting`
+ADD COLUMN (`min_age` bigint);
+
+UPDATE `empty_trash_setting`
+SET `min_age` = 604800000;
+
+ALTER TABLE `empty_trash_setting`
+MODIFY `min_age` bigint NOT NULL;

--- a/modules/store/src/main/resources/db/migration/postgresql/V1.25.2__add_trash_min_age.sql
+++ b/modules/store/src/main/resources/db/migration/postgresql/V1.25.2__add_trash_min_age.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "empty_trash_setting"
+ADD COLUMN "min_age" bigint;
+
+UPDATE "empty_trash_setting"
+SET "min_age" = 604800000;
+
+ALTER TABLE "empty_trash_setting"
+ALTER COLUMN "min_age" SET NOT NULL;

--- a/modules/store/src/main/scala/docspell/store/impl/DoobieMeta.scala
+++ b/modules/store/src/main/scala/docspell/store/impl/DoobieMeta.scala
@@ -34,6 +34,9 @@ trait DoobieMeta extends EmilDoobieMeta {
       e.apply(a).noSpaces
     )
 
+  implicit val metaDuration: Meta[Duration] =
+    Meta[Long].imap(Duration.millis)(_.millis)
+
   implicit val metaCollectiveState: Meta[CollectiveState] =
     Meta[String].imap(CollectiveState.unsafe)(CollectiveState.asString)
 

--- a/modules/store/src/main/scala/docspell/store/queries/QUserTask.scala
+++ b/modules/store/src/main/scala/docspell/store/queries/QUserTask.scala
@@ -54,15 +54,23 @@ object QUserTask {
       )
     ).query[RPeriodicTask].option.map(_.map(makeUserTask))
 
-  def insert(scope: UserTaskScope, task: UserTask[String]): ConnectionIO[Int] =
+  def insert(
+      scope: UserTaskScope,
+      subject: Option[String],
+      task: UserTask[String]
+  ): ConnectionIO[Int] =
     for {
-      r <- task.toPeriodicTask[ConnectionIO](scope)
+      r <- task.toPeriodicTask[ConnectionIO](scope, subject)
       n <- RPeriodicTask.insert(r)
     } yield n
 
-  def update(scope: UserTaskScope, task: UserTask[String]): ConnectionIO[Int] =
+  def update(
+      scope: UserTaskScope,
+      subject: Option[String],
+      task: UserTask[String]
+  ): ConnectionIO[Int] =
     for {
-      r <- task.toPeriodicTask[ConnectionIO](scope)
+      r <- task.toPeriodicTask[ConnectionIO](scope, subject)
       n <- RPeriodicTask.update(r)
     } yield n
 

--- a/modules/store/src/main/scala/docspell/store/records/RCollective.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RCollective.scala
@@ -13,7 +13,6 @@ import docspell.common._
 import docspell.store.qb.DSL._
 import docspell.store.qb._
 
-import com.github.eikek.calev._
 import doobie._
 import doobie.implicits._
 
@@ -75,16 +74,15 @@ object RCollective {
         )
       )
       now <- Timestamp.current[ConnectionIO]
-      cls = settings.classifier.map(_.toRecord(cid, now))
-      n2 <- cls match {
-        case Some(cr) =>
-          RClassifierSetting.update(cr)
+      n2 <- settings.classifier match {
+        case Some(cls) =>
+          RClassifierSetting.update(cls.toRecord(cid, now))
         case None =>
           RClassifierSetting.delete(cid)
       }
       n3 <- settings.emptyTrash match {
-        case Some(trashSchedule) =>
-          REmptyTrashSetting.update(REmptyTrashSetting(cid, trashSchedule, now))
+        case Some(trash) =>
+          REmptyTrashSetting.update(trash.toRecord(cid, now))
         case None =>
           REmptyTrashSetting.delete(cid)
       }
@@ -114,7 +112,8 @@ object RCollective {
         cs.itemCount.s,
         cs.categories.s,
         cs.listType.s,
-        es.schedule.s
+        es.schedule.s,
+        es.minAge.s
       ),
       from(c).leftJoin(cs, cs.cid === c.id).leftJoin(es, es.cid === c.id),
       c.id === coll
@@ -168,7 +167,7 @@ object RCollective {
       language: Language,
       integrationEnabled: Boolean,
       classifier: Option[RClassifierSetting.Classifier],
-      emptyTrash: Option[CalEvent]
+      emptyTrash: Option[REmptyTrashSetting.EmptyTrash]
   )
 
 }

--- a/modules/store/src/main/scala/docspell/store/records/RItem.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RItem.scala
@@ -389,8 +389,16 @@ object RItem {
   def findById(itemId: Ident): ConnectionIO[Option[RItem]] =
     run(select(T.all), from(T), T.id === itemId).query[RItem].option
 
-  def findDeleted(collective: Ident, chunkSize: Int): Stream[ConnectionIO, RItem] =
-    run(select(T.all), from(T), T.cid === collective && T.state === ItemState.deleted)
+  def findDeleted(
+      collective: Ident,
+      maxUpdated: Timestamp,
+      chunkSize: Int
+  ): Stream[ConnectionIO, RItem] =
+    run(
+      select(T.all),
+      from(T),
+      T.cid === collective && T.state === ItemState.deleted && T.updated < maxUpdated
+    )
       .query[RItem]
       .streamWithChunkSize(chunkSize)
 

--- a/modules/store/src/main/scala/docspell/store/usertask/UserTask.scala
+++ b/modules/store/src/main/scala/docspell/store/usertask/UserTask.scala
@@ -43,7 +43,8 @@ object UserTask {
         .map(a => ut.copy(args = a))
 
     def toPeriodicTask[F[_]: Sync](
-        scope: UserTaskScope
+        scope: UserTaskScope,
+        subject: Option[String]
     ): F[RPeriodicTask] =
       RPeriodicTask
         .create[F](
@@ -51,7 +52,7 @@ object UserTask {
           scope,
           ut.name,
           ut.args,
-          s"${scope.fold(_.user.id, _.id)}: ${ut.name.id}",
+          subject.getOrElse(s"${scope.fold(_.user.id, _.id)}: ${ut.name.id}"),
           Priority.Low,
           ut.timer,
           ut.summary

--- a/modules/webapp/src/main/elm/Api.elm
+++ b/modules/webapp/src/main/elm/Api.elm
@@ -158,6 +158,7 @@ import Api.Model.CustomFieldValue exposing (CustomFieldValue)
 import Api.Model.DirectionValue exposing (DirectionValue)
 import Api.Model.EmailSettings exposing (EmailSettings)
 import Api.Model.EmailSettingsList exposing (EmailSettingsList)
+import Api.Model.EmptyTrashSetting exposing (EmptyTrashSetting)
 import Api.Model.Equipment exposing (Equipment)
 import Api.Model.EquipmentList exposing (EquipmentList)
 import Api.Model.FolderDetail exposing (FolderDetail)
@@ -999,13 +1000,14 @@ startClassifier flags receive =
 
 startEmptyTrash :
     Flags
+    -> EmptyTrashSetting
     -> (Result Http.Error BasicResult -> msg)
     -> Cmd msg
-startEmptyTrash flags receive =
+startEmptyTrash flags setting receive =
     Http2.authPost
         { url = flags.config.baseUrl ++ "/api/v1/sec/collective/emptytrash/startonce"
         , account = getAccount flags
-        , body = Http.emptyBody
+        , body = Http.jsonBody (Api.Model.EmptyTrashSetting.encode setting)
         , expect = Http.expectJson receive Api.Model.BasicResult.decoder
         }
 

--- a/modules/webapp/src/main/elm/Comp/IntField.elm
+++ b/modules/webapp/src/main/elm/Comp/IntField.elm
@@ -47,13 +47,13 @@ init min max opt =
 tooLow : Model -> Int -> Bool
 tooLow model n =
     Maybe.map ((<) n) model.min
-        |> Maybe.withDefault (not model.optional)
+        |> Maybe.withDefault False
 
 
 tooHigh : Model -> Int -> Bool
 tooHigh model n =
     Maybe.map ((>) n) model.max
-        |> Maybe.withDefault (not model.optional)
+        |> Maybe.withDefault False
 
 
 update : Msg -> Model -> ( Model, Maybe Int )

--- a/modules/webapp/src/main/elm/Messages/Comp/CollectiveSettingsForm.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/CollectiveSettingsForm.elm
@@ -40,6 +40,7 @@ type alias Texts =
     , languageLabel : Language -> String
     , classifierTaskStarted : String
     , emptyTrashTaskStarted : String
+    , emptyTrashStartInvalidForm : String
     , fulltextReindexSubmitted : String
     , fulltextReindexOkMissing : String
     , emptyTrash : String
@@ -71,6 +72,7 @@ gb =
     , languageLabel = Messages.Data.Language.gb
     , classifierTaskStarted = "Classifier task started."
     , emptyTrashTaskStarted = "Empty trash task started."
+    , emptyTrashStartInvalidForm = "The empty-trash form contains errors."
     , fulltextReindexSubmitted = "Fulltext Re-Index started."
     , fulltextReindexOkMissing =
         "Please type OK in the field if you really want to start re-indexing your data."
@@ -103,6 +105,7 @@ de =
     , languageLabel = Messages.Data.Language.de
     , classifierTaskStarted = "Kategorisierung gestartet."
     , emptyTrashTaskStarted = "Papierkorb löschen gestartet."
+    , emptyTrashStartInvalidForm = "Das Papierkorb-Löschen Formular ist fehlerhaft!"
     , fulltextReindexSubmitted = "Volltext Neu-Indexierung gestartet."
     , fulltextReindexOkMissing =
         "Bitte tippe OK in das Feld ein, wenn Du wirklich den Index neu erzeugen möchtest."

--- a/modules/webapp/src/main/elm/Messages/Comp/EmptyTrashForm.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/EmptyTrashForm.elm
@@ -19,6 +19,8 @@ type alias Texts =
     { basics : Messages.Basics.Texts
     , calEventInput : Messages.Comp.CalEventInput.Texts
     , schedule : String
+    , minAge : String
+    , minAgeInfo : String
     }
 
 
@@ -27,6 +29,8 @@ gb =
     { basics = Messages.Basics.gb
     , calEventInput = Messages.Comp.CalEventInput.gb
     , schedule = "Schedule"
+    , minAge = "Minimum Age (Days)"
+    , minAgeInfo = "The minimum age in days of an items to be removed. The last-update time is used."
     }
 
 
@@ -35,4 +39,6 @@ de =
     { basics = Messages.Basics.de
     , calEventInput = Messages.Comp.CalEventInput.de
     , schedule = "Zeitplan"
+    , minAge = "Mindestalter (Tage)"
+    , minAgeInfo = "Das Mindestalter (in Tagen) der Dokumente, die gelöscht werden. Es wird das Datum der letzten Veränderung verwendet."
     }

--- a/modules/webapp/src/main/elm/Page/Home/View2.elm
+++ b/modules/webapp/src/main/elm/Page/Home/View2.elm
@@ -16,6 +16,7 @@ import Comp.SearchMenu
 import Comp.SearchStatsView
 import Data.Flags exposing (Flags)
 import Data.ItemSelection
+import Data.SearchMode
 import Data.UiSettings exposing (UiSettings)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -78,6 +79,7 @@ confirmModal texts model =
                         texts.basics.yes
                         texts.basics.no
                         texts.reallyDeleteQuestion
+
                 ConfirmRestore ->
                     Comp.ConfirmModal.defaultSettings
                         RestoreSelectedConfirmed
@@ -85,7 +87,6 @@ confirmModal texts model =
                         texts.basics.yes
                         texts.basics.no
                         texts.reallyRestoreQuestion
-
     in
     case model.viewMode of
         SelectView svm ->
@@ -270,6 +271,7 @@ editMenuBar texts model svm =
                 , inputClass =
                     [ ( btnStyle, True )
                     , ( "bg-gray-200 dark:bg-bluegray-600", svm.action == DeleteSelected )
+                    , ( "hidden", model.searchMenuModel.searchMode == Data.SearchMode.Trashed )
                     ]
                 }
             , MB.CustomButton
@@ -280,6 +282,7 @@ editMenuBar texts model svm =
                 , inputClass =
                     [ ( btnStyle, True )
                     , ( "bg-gray-200 dark:bg-bluegray-600", svm.action == RestoreSelected )
+                    , ( "hidden", model.searchMenuModel.searchMode == Data.SearchMode.Normal )
                     ]
                 }
             ]


### PR DESCRIPTION
In order to keep deleted items for a while, the periodic task can now
use a duration to only remove items with a certain age. This can be
used to ensure that a deleted item stays at least X days before it
will be removed from the database.

Refs: #347