### PR TITLE
Add the attachment-only option to a source

### DIFF
--- a/modules/backend/src/main/scala/docspell/backend/ops/OUpload.scala
+++ b/modules/backend/src/main/scala/docspell/backend/ops/OUpload.scala
@@ -183,7 +183,9 @@ object OUpload {
                 if (data.meta.fileFilter == Glob.all) src.source.fileFilterOrAll
                 else data.meta.fileFilter,
               tags = (data.meta.tags ++ src.tags.map(_.tagId.id)).distinct,
-              language = data.meta.language.orElse(src.source.language)
+              language = data.meta.language.orElse(src.source.language),
+              attachmentsOnly =
+                data.meta.attachmentsOnly.orElse(src.source.attachmentsOnly.some)
             ),
             priority = src.source.priority
           )

--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -5402,6 +5402,7 @@ components:
         - enabled
         - priority
         - created
+        - attachmentsOnly
       properties:
         id:
           type: string
@@ -5434,6 +5435,8 @@ components:
           description: DateTime
           type: integer
           format: date-time
+        attachmentsOnly:
+          type: boolean
     SourceTagIn:
       description: |
         A source and optional tags (ids or names) for updating/adding.

--- a/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
@@ -584,7 +584,8 @@ trait Conversions {
         s.source.folderId,
         s.source.fileFilter,
         s.source.language,
-        s.source.created
+        s.source.created,
+        s.source.attachmentsOnly
       ),
       TagList(s.tags.length, s.tags.map(mkTag).toList)
     )
@@ -602,7 +603,8 @@ trait Conversions {
         now,
         s.folder,
         s.fileFilter,
-        s.language
+        s.language,
+        s.attachmentsOnly
       )
     }
 
@@ -618,7 +620,8 @@ trait Conversions {
       s.created,
       s.folder,
       s.fileFilter,
-      s.language
+      s.language,
+      s.attachmentsOnly
     )
 
   // equipment

--- a/modules/store/src/main/resources/db/migration/h2/V1.25.4__add_source_attachonly.sql
+++ b/modules/store/src/main/resources/db/migration/h2/V1.25.4__add_source_attachonly.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "source"
+ADD COLUMN "attachments_only" BOOLEAN NULL;
+
+UPDATE "source"
+SET  "attachments_only" = FALSE;
+
+ALTER TABLE "source"
+ALTER COLUMN "attachments_only" SET NOT NULL;

--- a/modules/store/src/main/resources/db/migration/mariadb/V1.25.4__add_source_attachonly.sql
+++ b/modules/store/src/main/resources/db/migration/mariadb/V1.25.4__add_source_attachonly.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `source`
+ADD COLUMN (`attachments_only` BOOLEAN);
+
+UPDATE `source`
+SET  `attachments_only` = false;
+
+ALTER TABLE `source`
+MODIFY `attachments_only` BOOLEAN NOT NULL;

--- a/modules/store/src/main/resources/db/migration/postgresql/V1.25.4__add_source_attachonly.sql
+++ b/modules/store/src/main/resources/db/migration/postgresql/V1.25.4__add_source_attachonly.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "source"
+ADD COLUMN "attachments_only" BOOLEAN NULL;
+
+UPDATE "source"
+SET  "attachments_only" = FALSE;
+
+ALTER TABLE "source"
+ALTER COLUMN "attachments_only" SET NOT NULL;

--- a/modules/store/src/main/scala/docspell/store/records/RSource.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RSource.scala
@@ -26,7 +26,8 @@ case class RSource(
     created: Timestamp,
     folderId: Option[Ident],
     fileFilter: Option[Glob],
-    language: Option[Language]
+    language: Option[Language],
+    attachmentsOnly: Boolean
 ) {
 
   def fileFilterOrAll: Glob =
@@ -49,6 +50,7 @@ object RSource {
     val folder      = Column[Ident]("folder_id", this)
     val fileFilter  = Column[Glob]("file_filter", this)
     val language    = Column[Language]("doc_lang", this)
+    val attachOnly  = Column[Boolean]("attachments_only", this)
 
     val all =
       NonEmptyList.of[Column[_]](
@@ -62,7 +64,8 @@ object RSource {
         created,
         folder,
         fileFilter,
-        language
+        language,
+        attachOnly
       )
   }
 
@@ -90,7 +93,8 @@ object RSource {
         table.priority.setTo(v.priority),
         table.folder.setTo(v.folderId),
         table.fileFilter.setTo(v.fileFilter),
-        table.language.setTo(v.language)
+        table.language.setTo(v.language),
+        table.attachOnly.setTo(v.attachmentsOnly)
       )
     )
 

--- a/modules/webapp/src/main/elm/Comp/SourceForm.elm
+++ b/modules/webapp/src/main/elm/Comp/SourceForm.elm
@@ -57,6 +57,7 @@ type alias Model =
     , fileFilter : Maybe String
     , languageModel : Comp.Dropdown.Model Language
     , language : Maybe String
+    , attachmentsOnly : Bool
     }
 
 
@@ -80,6 +81,7 @@ emptyModel =
             , selected = Nothing
             }
     , language = Nothing
+    , attachmentsOnly = False
     }
 
 
@@ -119,6 +121,7 @@ getSource model =
                 , folder = model.folderId
                 , fileFilter = model.fileFilter
                 , language = model.language
+                , attachmentsOnly = model.attachmentsOnly
             }
     in
     { st | source = n, tags = TagList (List.length tags) tags }
@@ -136,6 +139,7 @@ type Msg
     | TagDropdownMsg (Comp.Dropdown.Msg Tag)
     | SetFileFilter String
     | LanguageMsg (Comp.Dropdown.Msg Language)
+    | ToggleAttachmentsOnly
 
 
 
@@ -218,6 +222,9 @@ update flags msg model =
 
         ToggleEnabled ->
             ( { model | enabled = not model.enabled }, Cmd.none )
+
+        ToggleAttachmentsOnly ->
+            ( { model | attachmentsOnly = not model.attachmentsOnly }, Cmd.none )
 
         SetAbbrev n ->
             ( { model | abbrev = n }, Cmd.none )
@@ -494,6 +501,24 @@ view2 flags texts settings model =
                 []
             , div [ class "opacity-50 text-sm" ]
                 [ Markdown.toHtml [] texts.fileFilterInfo
+                ]
+            ]
+        , div [ class "mb-4" ]
+            [ label
+                [ class "inline-flex items-center"
+                , for "attachments-only"
+                ]
+                [ input
+                    [ type_ "checkbox"
+                    , onCheck (\_ -> ToggleAttachmentsOnly)
+                    , checked model.attachmentsOnly
+                    , class S.checkboxInput
+                    , id "attachments-only"
+                    ]
+                    []
+                , span [ class "ml-2" ]
+                    [ text texts.attachmentsOnly
+                    ]
                 ]
             ]
         , div [ class "mb-4" ]

--- a/modules/webapp/src/main/elm/Messages/Comp/SourceForm.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/SourceForm.elm
@@ -31,6 +31,7 @@ type alias Texts =
     , language : String
     , languageInfo : String
     , languageLabel : Language -> String
+    , attachmentsOnly : String
     }
 
 
@@ -61,6 +62,7 @@ Specify a file glob to filter files when uploading archives
         "Used for text extraction and analysis. The collective's "
             ++ "default language is used if not specified here."
     , languageLabel = Messages.Data.Language.gb
+    , attachmentsOnly = "Only import attachments for e-mails"
     }
 
 
@@ -93,4 +95,5 @@ importieren: `*.pdf`. Globs können auch mittels OR kombiniert werden:
         "Wird für die Texterkennung und -analyse verwendet. Die Standardsprache des Kollektivs "
             ++ "wird verwendet, falls hier nicht angegeben."
     , languageLabel = Messages.Data.Language.de
+    , attachmentsOnly = "Bei E-Mails nur die Anhänge importieren"
     }


### PR DESCRIPTION
The upload request can now contain a boolean for importing only
attachments when e-mails are uploaded. This option is now also added
to a source url.

Refs: #983