### PR TITLE
Allow to specify ordering when retrieving meta data

### DIFF
--- a/modules/backend/src/main/scala/docspell/backend/ops/OFolder.scala
+++ b/modules/backend/src/main/scala/docspell/backend/ops/OFolder.scala
@@ -6,6 +6,7 @@
 
 package docspell.backend.ops
 
+import cats.data.{NonEmptyList => Nel}
 import cats.effect._
 
 import docspell.common._
@@ -18,7 +19,8 @@ trait OFolder[F[_]] {
   def findAll(
       account: AccountId,
       ownerLogin: Option[Ident],
-      nameQuery: Option[String]
+      query: Option[String],
+      order: OFolder.FolderOrder
   ): F[Vector[OFolder.FolderItem]]
 
   def findById(id: Ident, account: AccountId): F[Option[OFolder.FolderDetail]]
@@ -50,6 +52,7 @@ trait OFolder[F[_]] {
 }
 
 object OFolder {
+  import docspell.store.qb.DSL._
 
   type FolderChangeResult = QFolder.FolderChangeResult
   val FolderChangeResult = QFolder.FolderChangeResult
@@ -60,14 +63,45 @@ object OFolder {
   type FolderDetail = QFolder.FolderDetail
   val FolderDetail = QFolder.FolderDetail
 
+  sealed trait FolderOrder
+  object FolderOrder {
+    final case object NameAsc   extends FolderOrder
+    final case object NameDesc  extends FolderOrder
+    final case object OwnerAsc  extends FolderOrder
+    final case object OwnerDesc extends FolderOrder
+
+    def parse(str: String): Either[String, FolderOrder] =
+      str.toLowerCase match {
+        case "name"   => Right(NameAsc)
+        case "-name"  => Right(NameDesc)
+        case "owner"  => Right(OwnerAsc)
+        case "-owner" => Right(OwnerDesc)
+        case _        => Left(s"Unknown sort property for folder: $str")
+      }
+
+    def parseOrDefault(str: String): FolderOrder =
+      parse(str).toOption.getOrElse(NameAsc)
+
+    private[ops] def apply(order: FolderOrder)(folder: RFolder.Table, user: RUser.Table) =
+      order match {
+        case NameAsc   => Nel.of(folder.name.asc)
+        case NameDesc  => Nel.of(folder.name.desc)
+        case OwnerAsc  => Nel.of(user.login.asc, folder.name.asc)
+        case OwnerDesc => Nel.of(user.login.desc, folder.name.desc)
+      }
+  }
+
   def apply[F[_]](store: Store[F]): Resource[F, OFolder[F]] =
     Resource.pure[F, OFolder[F]](new OFolder[F] {
       def findAll(
           account: AccountId,
           ownerLogin: Option[Ident],
-          nameQuery: Option[String]
+          query: Option[String],
+          order: FolderOrder
       ): F[Vector[FolderItem]] =
-        store.transact(QFolder.findAll(account, None, ownerLogin, nameQuery))
+        store.transact(
+          QFolder.findAll(account, None, ownerLogin, query, FolderOrder(order))
+        )
 
       def findById(id: Ident, account: AccountId): F[Option[FolderDetail]] =
         store.transact(QFolder.findById(id, account))

--- a/modules/backend/src/main/scala/docspell/backend/ops/OOrganization.scala
+++ b/modules/backend/src/main/scala/docspell/backend/ops/OOrganization.scala
@@ -6,6 +6,7 @@
 
 package docspell.backend.ops
 
+import cats.data.NonEmptyList
 import cats.effect.{Async, Resource}
 import cats.implicits._
 
@@ -16,10 +17,18 @@ import docspell.store.queries.QOrganization
 import docspell.store.records._
 
 trait OOrganization[F[_]] {
-  def findAllOrg(account: AccountId, query: Option[String]): F[Vector[OrgAndContacts]]
+  def findAllOrg(
+      account: AccountId,
+      query: Option[String],
+      order: OrganizationOrder
+  ): F[Vector[OrgAndContacts]]
   def findOrg(account: AccountId, orgId: Ident): F[Option[OrgAndContacts]]
 
-  def findAllOrgRefs(account: AccountId, nameQuery: Option[String]): F[Vector[IdRef]]
+  def findAllOrgRefs(
+      account: AccountId,
+      nameQuery: Option[String],
+      order: OrganizationOrder
+  ): F[Vector[IdRef]]
 
   def addOrg(s: OrgAndContacts): F[AddResult]
 
@@ -27,12 +36,17 @@ trait OOrganization[F[_]] {
 
   def findAllPerson(
       account: AccountId,
-      query: Option[String]
+      query: Option[String],
+      order: PersonOrder
   ): F[Vector[PersonAndContacts]]
 
   def findPerson(account: AccountId, persId: Ident): F[Option[PersonAndContacts]]
 
-  def findAllPersonRefs(account: AccountId, nameQuery: Option[String]): F[Vector[IdRef]]
+  def findAllPersonRefs(
+      account: AccountId,
+      nameQuery: Option[String],
+      order: PersonOrder
+  ): F[Vector[IdRef]]
 
   /** Add a new person with their contacts. The additional organization is ignored. */
   def addPerson(s: PersonAndContacts): F[AddResult]
@@ -46,6 +60,7 @@ trait OOrganization[F[_]] {
 }
 
 object OOrganization {
+  import docspell.store.qb.DSL._
 
   case class OrgAndContacts(org: ROrganization, contacts: Seq[RContact])
 
@@ -55,15 +70,79 @@ object OOrganization {
       contacts: Seq[RContact]
   )
 
+  sealed trait OrganizationOrder
+  object OrganizationOrder {
+    final case object NameAsc  extends OrganizationOrder
+    final case object NameDesc extends OrganizationOrder
+
+    def parse(str: String): Either[String, OrganizationOrder] =
+      str.toLowerCase match {
+        case "name"  => Right(NameAsc)
+        case "-name" => Right(NameDesc)
+        case _       => Left(s"Unknown sort property for organization: $str")
+      }
+
+    def parseOrDefault(str: String): OrganizationOrder =
+      parse(str).toOption.getOrElse(NameAsc)
+
+    private[ops] def apply(order: OrganizationOrder)(table: ROrganization.Table) =
+      order match {
+        case NameAsc  => NonEmptyList.of(table.name.asc)
+        case NameDesc => NonEmptyList.of(table.name.desc)
+      }
+  }
+
+  sealed trait PersonOrder
+  object PersonOrder {
+    final case object NameAsc  extends PersonOrder
+    final case object NameDesc extends PersonOrder
+    final case object OrgAsc   extends PersonOrder
+    final case object OrgDesc  extends PersonOrder
+
+    def parse(str: String): Either[String, PersonOrder] =
+      str.toLowerCase match {
+        case "name"  => Right(NameAsc)
+        case "-name" => Right(NameDesc)
+        case "org"   => Right(OrgAsc)
+        case "-org"  => Right(OrgDesc)
+        case _       => Left(s"Unknown sort property for person: $str")
+      }
+
+    def parseOrDefault(str: String): PersonOrder =
+      parse(str).toOption.getOrElse(NameAsc)
+
+    private[ops] def apply(
+        order: PersonOrder
+    )(person: RPerson.Table, org: ROrganization.Table) =
+      order match {
+        case NameAsc  => NonEmptyList.of(person.name.asc)
+        case NameDesc => NonEmptyList.of(person.name.desc)
+        case OrgAsc   => NonEmptyList.of(org.name.asc)
+        case OrgDesc  => NonEmptyList.of(org.name.desc)
+      }
+
+    private[ops] def nameOnly(order: PersonOrder)(person: RPerson.Table) =
+      order match {
+        case NameAsc  => NonEmptyList.of(person.name.asc)
+        case NameDesc => NonEmptyList.of(person.name.desc)
+        case OrgAsc   => NonEmptyList.of(person.name.asc)
+        case OrgDesc  => NonEmptyList.of(person.name.asc)
+      }
+  }
+
   def apply[F[_]: Async](store: Store[F]): Resource[F, OOrganization[F]] =
     Resource.pure[F, OOrganization[F]](new OOrganization[F] {
 
       def findAllOrg(
           account: AccountId,
-          query: Option[String]
+          query: Option[String],
+          order: OrganizationOrder
       ): F[Vector[OrgAndContacts]] =
         store
-          .transact(QOrganization.findOrgAndContact(account.collective, query, _.name))
+          .transact(
+            QOrganization
+              .findOrgAndContact(account.collective, query, OrganizationOrder(order))
+          )
           .map { case (org, cont) => OrgAndContacts(org, cont) }
           .compile
           .toVector
@@ -75,9 +154,16 @@ object OOrganization {
 
       def findAllOrgRefs(
           account: AccountId,
-          nameQuery: Option[String]
+          nameQuery: Option[String],
+          order: OrganizationOrder
       ): F[Vector[IdRef]] =
-        store.transact(ROrganization.findAllRef(account.collective, nameQuery, _.name))
+        store.transact(
+          ROrganization.findAllRef(
+            account.collective,
+            nameQuery,
+            OrganizationOrder(order)
+          )
+        )
 
       def addOrg(s: OrgAndContacts): F[AddResult] =
         QOrganization.addOrg(s.org, s.contacts, s.org.cid)(store)
@@ -87,10 +173,14 @@ object OOrganization {
 
       def findAllPerson(
           account: AccountId,
-          query: Option[String]
+          query: Option[String],
+          order: PersonOrder
       ): F[Vector[PersonAndContacts]] =
         store
-          .transact(QOrganization.findPersonAndContact(account.collective, query, _.name))
+          .transact(
+            QOrganization
+              .findPersonAndContact(account.collective, query, PersonOrder(order))
+          )
           .map { case (person, org, cont) => PersonAndContacts(person, org, cont) }
           .compile
           .toVector
@@ -102,9 +192,12 @@ object OOrganization {
 
       def findAllPersonRefs(
           account: AccountId,
-          nameQuery: Option[String]
+          nameQuery: Option[String],
+          order: PersonOrder
       ): F[Vector[IdRef]] =
-        store.transact(RPerson.findAllRef(account.collective, nameQuery, _.name))
+        store.transact(
+          RPerson.findAllRef(account.collective, nameQuery, PersonOrder.nameOnly(order))
+        )
 
       def addPerson(s: PersonAndContacts): F[AddResult] =
         QOrganization.addPerson(s.person, s.contacts, s.person.cid)(store)

--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -501,11 +501,14 @@ paths:
       tags: [ Tags ]
       summary: Get a list of tags
       description: |
-        Return a list of all configured tags.
+        Return a list of all configured tags. The `sort` query
+        parameter is optional and can specify how the list is sorted.
+        Possible values are: `name`, `-name`, `category`, `-category`.
       security:
         - authTokenHeader: []
       parameters:
         - $ref: "#/components/parameters/q"
+        - $ref: "#/components/parameters/sort"
       responses:
         200:
           description: Ok
@@ -579,12 +582,16 @@ paths:
       tags: [ Organization ]
       summary: Get a list of organizations.
       description: |
-        Return a list of all organizations. Only name and id are returned.
+        Return a list of all organizations. Only name and id are
+        returned. If `full` is specified, the list contains all
+        organization data. The `sort` parameter can be either `name`
+        or `-name` to specify the order.
       security:
         - authTokenHeader: []
       parameters:
         - $ref: "#/components/parameters/full"
         - $ref: "#/components/parameters/q"
+        - $ref: "#/components/parameters/sort"
       responses:
         200:
           description: Ok
@@ -677,12 +684,17 @@ paths:
       tags: [ Person ]
       summary: Get a list of persons.
       description: |
-        Return a list of all persons. Only name and id are returned.
+        Return a list of all persons. Only name and id are returned
+        unless the `full` parameter is specified. The `sort` parameter
+        can be used to control the order of the result. Use one of:
+        `name`, `-name`, `org`, `-org`. Note that order by `org` only
+        works when retrieving the full list.
       security:
         - authTokenHeader: []
       parameters:
         - $ref: "#/components/parameters/full"
         - $ref: "#/components/parameters/q"
+        - $ref: "#/components/parameters/sort"
       responses:
         200:
           description: Ok
@@ -775,11 +787,14 @@ paths:
       tags: [ Equipment ]
       summary: Get a list of equipments
       description: |
-        Return a list of all configured equipments.
+        Return a list of all configured equipments. The sort query
+        parameter is optional and can be one of `name` or `-name` to
+        sort the list of equipments.
       security:
         - authTokenHeader: []
       parameters:
         - $ref: "#/components/parameters/q"
+        - $ref: "#/components/parameters/sort"
       responses:
         200:
           description: Ok
@@ -3771,11 +3786,15 @@ paths:
       tags: [ Custom Fields ]
       summary: Get all defined custom fields.
       description: |
-        Get all custom fields defined for the current collective.
+        Get all custom fields defined for the current collective. The
+        `sort` parameter can be used to control the order of the
+        returned list. It can take a value from: `name`, `-name`,
+        `label`, `-label`, `type`, `-type`.
       security:
         - authTokenHeader: []
       parameters:
         - $ref: "#/components/parameters/q"
+        - $ref: "#/components/parameters/sort"
       responses:
         200:
           description: Ok
@@ -5985,6 +6004,14 @@ components:
       schema:
         type: integer
         format: int32
+    sort:
+      name: sort
+      in: query
+      required: false
+      description: |
+        How to sort the returned list
+      schema:
+        type: string
     withDetails:
       name: withDetails
       in: query

--- a/modules/restserver/src/main/scala/docspell/restserver/http4s/QueryParam.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/http4s/QueryParam.scala
@@ -6,6 +6,11 @@
 
 package docspell.restserver.http4s
 
+import docspell.backend.ops.OCustomFields.CustomFieldOrder
+import docspell.backend.ops.OEquipment.EquipmentOrder
+import docspell.backend.ops.OFolder.FolderOrder
+import docspell.backend.ops.OOrganization.{OrganizationOrder, PersonOrder}
+import docspell.backend.ops.OTag.TagOrder
 import docspell.common.ContactKind
 import docspell.common.SearchMode
 
@@ -29,6 +34,36 @@ object QueryParam {
       SearchMode.fromString(str).left.map(s => ParseFailure(str, s))
     )
 
+  implicit val tagOrderDecoder: QueryParamDecoder[TagOrder] =
+    QueryParamDecoder[String].emap(str =>
+      TagOrder.parse(str).left.map(s => ParseFailure(str, s))
+    )
+
+  implicit val euqipOrderDecoder: QueryParamDecoder[EquipmentOrder] =
+    QueryParamDecoder[String].emap(str =>
+      EquipmentOrder.parse(str).left.map(s => ParseFailure(str, s))
+    )
+
+  implicit val orgOrderDecoder: QueryParamDecoder[OrganizationOrder] =
+    QueryParamDecoder[String].emap(str =>
+      OrganizationOrder.parse(str).left.map(s => ParseFailure(str, s))
+    )
+
+  implicit val personOrderDecoder: QueryParamDecoder[PersonOrder] =
+    QueryParamDecoder[String].emap(str =>
+      PersonOrder.parse(str).left.map(s => ParseFailure(str, s))
+    )
+
+  implicit val folderOrderDecoder: QueryParamDecoder[FolderOrder] =
+    QueryParamDecoder[String].emap(str =>
+      FolderOrder.parse(str).left.map(s => ParseFailure(str, s))
+    )
+
+  implicit val customFieldOrderDecoder: QueryParamDecoder[CustomFieldOrder] =
+    QueryParamDecoder[String].emap(str =>
+      CustomFieldOrder.parse(str).left.map(s => ParseFailure(str, s))
+    )
+
   object FullOpt extends OptionalQueryParamDecoderMatcher[Boolean]("full")
 
   object OwningOpt extends OptionalQueryParamDecoderMatcher[Boolean]("owning")
@@ -42,6 +77,12 @@ object QueryParam {
   object Offset      extends OptionalQueryParamDecoderMatcher[Int]("offset")
   object WithDetails extends OptionalQueryParamDecoderMatcher[Boolean]("withDetails")
   object SearchKind  extends OptionalQueryParamDecoderMatcher[SearchMode]("searchMode")
+  object TagSort     extends OptionalQueryParamDecoderMatcher[TagOrder]("sort")
+  object EquipSort   extends OptionalQueryParamDecoderMatcher[EquipmentOrder]("sort")
+  object OrgSort     extends OptionalQueryParamDecoderMatcher[OrganizationOrder]("sort")
+  object PersonSort  extends OptionalQueryParamDecoderMatcher[PersonOrder]("sort")
+  object FolderSort  extends OptionalQueryParamDecoderMatcher[FolderOrder]("sort")
+  object FieldSort   extends OptionalQueryParamDecoderMatcher[CustomFieldOrder]("sort")
 
   object WithFallback extends OptionalQueryParamDecoderMatcher[Boolean]("withFallback")
 }

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/CustomFieldRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/CustomFieldRoutes.scala
@@ -13,7 +13,7 @@ import cats.implicits._
 import docspell.backend.BackendApp
 import docspell.backend.auth.AuthToken
 import docspell.backend.ops.OCustomFields
-import docspell.backend.ops.OCustomFields.CustomFieldData
+import docspell.backend.ops.OCustomFields.{CustomFieldData, CustomFieldOrder}
 import docspell.common._
 import docspell.restapi.model._
 import docspell.restserver.conv.Conversions
@@ -34,9 +34,14 @@ object CustomFieldRoutes {
     import dsl._
 
     HttpRoutes.of {
-      case GET -> Root :? QueryParam.QueryOpt(param) =>
+      case GET -> Root :? QueryParam.QueryOpt(param) +& QueryParam.FieldSort(sort) =>
+        val order = sort.getOrElse(CustomFieldOrder.NameAsc)
         for {
-          fs  <- backend.customFields.findAll(user.account.collective, param.map(_.q))
+          fs <- backend.customFields.findAll(
+            user.account.collective,
+            param.map(_.q),
+            order
+          )
           res <- Ok(CustomFieldList(fs.map(convertField).toList))
         } yield res
 

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/EquipmentRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/EquipmentRoutes.scala
@@ -12,6 +12,7 @@ import cats.implicits._
 
 import docspell.backend.BackendApp
 import docspell.backend.auth.AuthToken
+import docspell.backend.ops.OEquipment
 import docspell.common.Ident
 import docspell.restapi.model._
 import docspell.restserver.conv.Conversions._
@@ -29,9 +30,13 @@ object EquipmentRoutes {
     import dsl._
 
     HttpRoutes.of {
-      case GET -> Root :? QueryParam.QueryOpt(q) =>
+      case GET -> Root :? QueryParam.QueryOpt(q) :? QueryParam.EquipSort(sort) =>
         for {
-          data <- backend.equipment.findAll(user.account, q.map(_.q))
+          data <- backend.equipment.findAll(
+            user.account,
+            q.map(_.q),
+            sort.getOrElse(OEquipment.EquipmentOrder.NameAsc)
+          )
           resp <- Ok(EquipmentList(data.map(mkEquipment).toList))
         } yield resp
 

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/FolderRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/FolderRoutes.scala
@@ -31,11 +31,13 @@ object FolderRoutes {
     import dsl._
 
     HttpRoutes.of {
-      case GET -> Root :? QueryParam.QueryOpt(q) :? QueryParam.OwningOpt(owning) =>
+      case GET -> Root :? QueryParam.QueryOpt(q) :?
+          QueryParam.OwningOpt(owning) +& QueryParam.FolderSort(sort) =>
+        val order = sort.getOrElse(OFolder.FolderOrder.NameAsc)
         val login =
           owning.filter(identity).map(_ => user.account.user)
         for {
-          all  <- backend.folder.findAll(user.account, login, q.map(_.q))
+          all  <- backend.folder.findAll(user.account, login, q.map(_.q), order)
           resp <- Ok(FolderList(all.map(mkFolder).toList))
         } yield resp
 

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/PersonRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/PersonRoutes.scala
@@ -12,6 +12,7 @@ import cats.implicits._
 
 import docspell.backend.BackendApp
 import docspell.backend.auth.AuthToken
+import docspell.backend.ops.OOrganization
 import docspell.common.Ident
 import docspell.common.syntax.all._
 import docspell.restapi.model._
@@ -32,15 +33,25 @@ object PersonRoutes {
     import dsl._
 
     HttpRoutes.of {
-      case GET -> Root :? QueryParam.FullOpt(full) +& QueryParam.QueryOpt(q) =>
+      case GET -> Root :? QueryParam.FullOpt(full) +&
+          QueryParam.QueryOpt(q) +& QueryParam.PersonSort(sort) =>
+        val order = sort.getOrElse(OOrganization.PersonOrder.NameAsc)
         if (full.getOrElse(false))
           for {
-            data <- backend.organization.findAllPerson(user.account, q.map(_.q))
+            data <- backend.organization.findAllPerson(
+              user.account,
+              q.map(_.q),
+              order
+            )
             resp <- Ok(PersonList(data.map(mkPerson).toList))
           } yield resp
         else
           for {
-            data <- backend.organization.findAllPersonRefs(user.account, q.map(_.q))
+            data <- backend.organization.findAllPersonRefs(
+              user.account,
+              q.map(_.q),
+              order
+            )
             resp <- Ok(ReferenceList(data.map(mkIdName).toList))
           } yield resp
 

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/TagRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/TagRoutes.scala
@@ -11,6 +11,7 @@ import cats.implicits._
 
 import docspell.backend.BackendApp
 import docspell.backend.auth.AuthToken
+import docspell.backend.ops.OTag.TagOrder
 import docspell.common.Ident
 import docspell.restapi.model._
 import docspell.restserver.conv.Conversions._
@@ -28,9 +29,13 @@ object TagRoutes {
     import dsl._
 
     HttpRoutes.of {
-      case GET -> Root :? QueryParam.QueryOpt(q) =>
+      case GET -> Root :? QueryParam.QueryOpt(q) :? QueryParam.TagSort(sort) =>
         for {
-          all  <- backend.tag.findAll(user.account, q.map(_.q))
+          all <- backend.tag.findAll(
+            user.account,
+            q.map(_.q),
+            sort.getOrElse(TagOrder.NameAsc)
+          )
           resp <- Ok(TagList(all.size, all.map(mkTag).toList))
         } yield resp
 

--- a/modules/store/src/main/scala/docspell/store/qb/Column.scala
+++ b/modules/store/src/main/scala/docspell/store/qb/Column.scala
@@ -12,6 +12,7 @@ case class Column[A](name: String, table: TableDef) {
 
   def cast[B]: Column[B] =
     this.asInstanceOf[Column[B]]
+
 }
 
 object Column {}

--- a/modules/store/src/main/scala/docspell/store/qb/DSL.scala
+++ b/modules/store/src/main/scala/docspell/store/qb/DSL.scala
@@ -303,6 +303,12 @@ trait DSL extends DoobieMeta {
     def as(otherCol: Column[_]): SelectExpr =
       SelectExpr.SelectFun(dbf, Some(otherCol.name))
 
+    def asc: OrderBy =
+      OrderBy(SelectExpr.SelectFun(dbf, None), OrderBy.OrderType.Asc)
+
+    def desc: OrderBy =
+      OrderBy(SelectExpr.SelectFun(dbf, None), OrderBy.OrderType.Desc)
+
     def ===[A](value: A)(implicit P: Put[A]): Condition =
       Condition.CompareFVal(dbf.s, Operator.Eq, value)
 

--- a/modules/store/src/main/scala/docspell/store/qb/Select.scala
+++ b/modules/store/src/main/scala/docspell/store/qb/Select.scala
@@ -135,6 +135,9 @@ object Select {
 
     def orderBy(ob: OrderBy, obs: OrderBy*): Ordered =
       Ordered(this, ob, obs.toVector)
+
+    def orderBy(ob: Nel[OrderBy]): Ordered =
+      Ordered(this, ob.head, ob.tail.toVector)
   }
 
   case class RawSelect(fragment: Fragment) extends Select {

--- a/modules/store/src/main/scala/docspell/store/records/REquipment.scala
+++ b/modules/store/src/main/scala/docspell/store/records/REquipment.scala
@@ -87,7 +87,7 @@ object REquipment {
   def findAll(
       coll: Ident,
       nameQ: Option[String],
-      order: Table => Column[_]
+      order: Table => NonEmptyList[OrderBy]
   ): ConnectionIO[Vector[REquipment]] = {
     val t = Table(None)
 

--- a/modules/store/src/main/scala/docspell/store/records/ROrganization.scala
+++ b/modules/store/src/main/scala/docspell/store/records/ROrganization.scala
@@ -7,7 +7,7 @@
 package docspell.store.records
 
 import cats.Eq
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList => Nel}
 import fs2.Stream
 
 import docspell.common.{IdRef, _}
@@ -52,7 +52,7 @@ object ROrganization {
     val shortName = Column[String]("short_name", this)
     val use       = Column[OrgUse]("org_use", this)
     val all =
-      NonEmptyList.of[Column[_]](
+      Nel.of[Column[_]](
         oid,
         cid,
         name,
@@ -122,7 +122,7 @@ object ROrganization {
   def findLike(
       coll: Ident,
       orgName: String,
-      use: NonEmptyList[OrgUse]
+      use: Nel[OrgUse]
   ): ConnectionIO[Vector[IdRef]] =
     run(
       select(T.oid, T.name),
@@ -163,7 +163,7 @@ object ROrganization {
   def findAllRef(
       coll: Ident,
       nameQ: Option[String],
-      order: Table => Column[_]
+      order: Table => Nel[OrderBy]
   ): ConnectionIO[Vector[IdRef]] = {
     val nameFilter = nameQ.map(s =>
       T.name.like(s"%${s.toLowerCase}%") || T.shortName.like(s"%${s.toLowerCase}%")

--- a/modules/store/src/main/scala/docspell/store/records/RPerson.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RPerson.scala
@@ -7,7 +7,7 @@
 package docspell.store.records
 
 import cats.Eq
-import cats.data.NonEmptyList
+import cats.data.{NonEmptyList => Nel}
 import cats.effect._
 import fs2.Stream
 
@@ -52,7 +52,7 @@ object RPerson {
     val updated = Column[Timestamp]("updated", this)
     val oid     = Column[Ident]("oid", this)
     val use     = Column[PersonUse]("person_use", this)
-    val all = NonEmptyList.of[Column[_]](
+    val all = Nel.of[Column[_]](
       pid,
       cid,
       name,
@@ -122,7 +122,7 @@ object RPerson {
   def findLike(
       coll: Ident,
       personName: String,
-      use: NonEmptyList[PersonUse]
+      use: Nel[PersonUse]
   ): ConnectionIO[Vector[IdRef]] =
     run(
       select(T.pid, T.name),
@@ -134,7 +134,7 @@ object RPerson {
       coll: Ident,
       contactKind: ContactKind,
       value: String,
-      use: NonEmptyList[PersonUse]
+      use: Nel[PersonUse]
   ): ConnectionIO[Vector[IdRef]] = {
     val p = RPerson.as("p")
     val c = RContact.as("c")
@@ -162,7 +162,7 @@ object RPerson {
   def findAllRef(
       coll: Ident,
       nameQ: Option[String],
-      order: Table => Column[_]
+      order: Table => Nel[OrderBy]
   ): ConnectionIO[Vector[IdRef]] = {
 
     val nameFilter = nameQ.map(s => T.name.like(s"%${s.toLowerCase}%"))
@@ -176,7 +176,7 @@ object RPerson {
     DML.delete(T, T.pid === personId && T.cid === coll)
 
   def findOrganization(ids: Set[Ident]): ConnectionIO[Vector[PersonRef]] =
-    NonEmptyList.fromList(ids.toList) match {
+    Nel.fromList(ids.toList) match {
       case Some(nel) =>
         run(select(T.pid, T.name, T.oid), from(T), T.pid.in(nel))
           .query[PersonRef]

--- a/modules/store/src/main/scala/docspell/store/records/RTag.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RTag.scala
@@ -75,10 +75,11 @@ object RTag {
 
   def findAll(
       coll: Ident,
-      nameQ: Option[String],
-      order: Table => Column[_]
+      query: Option[String],
+      order: Table => NonEmptyList[OrderBy]
   ): ConnectionIO[Vector[RTag]] = {
-    val nameFilter = nameQ.map(s => T.name.like(s"%${s.toLowerCase}%"))
+    val nameFilter =
+      query.map(_.toLowerCase).map(s => T.name.like(s"%$s%") || T.category.like(s"%$s%"))
     val sql =
       Select(select(T.all), from(T), T.cid === coll &&? nameFilter).orderBy(order(T))
     sql.build.query[RTag].to[Vector]

--- a/modules/webapp/src/main/elm/Api.elm
+++ b/modules/webapp/src/main/elm/Api.elm
@@ -216,8 +216,14 @@ import Api.Model.UserList exposing (UserList)
 import Api.Model.UserPass exposing (UserPass)
 import Api.Model.VersionInfo exposing (VersionInfo)
 import Data.ContactType exposing (ContactType)
+import Data.CustomFieldOrder exposing (CustomFieldOrder)
+import Data.EquipmentOrder exposing (EquipmentOrder)
 import Data.Flags exposing (Flags)
+import Data.FolderOrder exposing (FolderOrder)
+import Data.OrganizationOrder exposing (OrganizationOrder)
+import Data.PersonOrder exposing (PersonOrder)
 import Data.Priority exposing (Priority)
+import Data.TagOrder exposing (TagOrder)
 import Data.UiSettings exposing (UiSettings)
 import File exposing (File)
 import Http
@@ -291,13 +297,15 @@ putCustomValue flags item fieldValue receive =
         }
 
 
-getCustomFields : Flags -> String -> (Result Http.Error CustomFieldList -> msg) -> Cmd msg
-getCustomFields flags query receive =
+getCustomFields : Flags -> String -> CustomFieldOrder -> (Result Http.Error CustomFieldList -> msg) -> Cmd msg
+getCustomFields flags query order receive =
     Http2.authGet
         { url =
             flags.config.baseUrl
                 ++ "/api/v1/sec/customfield?q="
                 ++ Url.percentEncode query
+                ++ "&sort="
+                ++ Data.CustomFieldOrder.asString order
         , account = getAccount flags
         , expect = Http.expectJson receive Api.Model.CustomFieldList.decoder
         }
@@ -402,13 +410,21 @@ getFolderDetail flags id receive =
         }
 
 
-getFolders : Flags -> String -> Bool -> (Result Http.Error FolderList -> msg) -> Cmd msg
-getFolders flags query owningOnly receive =
+getFolders :
+    Flags
+    -> String
+    -> FolderOrder
+    -> Bool
+    -> (Result Http.Error FolderList -> msg)
+    -> Cmd msg
+getFolders flags query order owningOnly receive =
     Http2.authGet
         { url =
             flags.config.baseUrl
                 ++ "/api/v1/sec/folder?q="
                 ++ Url.percentEncode query
+                ++ "&sort="
+                ++ Data.FolderOrder.asString order
                 ++ (if owningOnly then
                         "&owning=true"
 
@@ -1109,10 +1125,15 @@ getContacts flags kind q receive =
 --- Tags
 
 
-getTags : Flags -> String -> (Result Http.Error TagList -> msg) -> Cmd msg
-getTags flags query receive =
+getTags : Flags -> String -> TagOrder -> (Result Http.Error TagList -> msg) -> Cmd msg
+getTags flags query order receive =
     Http2.authGet
-        { url = flags.config.baseUrl ++ "/api/v1/sec/tag?q=" ++ Url.percentEncode query
+        { url =
+            flags.config.baseUrl
+                ++ "/api/v1/sec/tag?sort="
+                ++ Data.TagOrder.asString order
+                ++ "&q="
+                ++ Url.percentEncode query
         , account = getAccount flags
         , expect = Http.expectJson receive Api.Model.TagList.decoder
         }
@@ -1148,10 +1169,15 @@ deleteTag flags tag receive =
 --- Equipments
 
 
-getEquipments : Flags -> String -> (Result Http.Error EquipmentList -> msg) -> Cmd msg
-getEquipments flags query receive =
+getEquipments : Flags -> String -> EquipmentOrder -> (Result Http.Error EquipmentList -> msg) -> Cmd msg
+getEquipments flags query order receive =
     Http2.authGet
-        { url = flags.config.baseUrl ++ "/api/v1/sec/equipment?q=" ++ Url.percentEncode query
+        { url =
+            flags.config.baseUrl
+                ++ "/api/v1/sec/equipment?q="
+                ++ Url.percentEncode query
+                ++ "&sort="
+                ++ Data.EquipmentOrder.asString order
         , account = getAccount flags
         , expect = Http.expectJson receive Api.Model.EquipmentList.decoder
         }
@@ -1214,10 +1240,20 @@ getOrgFull id flags receive =
         }
 
 
-getOrganizations : Flags -> String -> (Result Http.Error OrganizationList -> msg) -> Cmd msg
-getOrganizations flags query receive =
+getOrganizations :
+    Flags
+    -> String
+    -> OrganizationOrder
+    -> (Result Http.Error OrganizationList -> msg)
+    -> Cmd msg
+getOrganizations flags query order receive =
     Http2.authGet
-        { url = flags.config.baseUrl ++ "/api/v1/sec/organization?full=true&q=" ++ Url.percentEncode query
+        { url =
+            flags.config.baseUrl
+                ++ "/api/v1/sec/organization?full=true&q="
+                ++ Url.percentEncode query
+                ++ "&sort="
+                ++ Data.OrganizationOrder.asString order
         , account = getAccount flags
         , expect = Http.expectJson receive Api.Model.OrganizationList.decoder
         }
@@ -1271,10 +1307,15 @@ getPersonFull id flags receive =
         }
 
 
-getPersons : Flags -> String -> (Result Http.Error PersonList -> msg) -> Cmd msg
-getPersons flags query receive =
+getPersons : Flags -> String -> PersonOrder -> (Result Http.Error PersonList -> msg) -> Cmd msg
+getPersons flags query order receive =
     Http2.authGet
-        { url = flags.config.baseUrl ++ "/api/v1/sec/person?full=true&q=" ++ Url.percentEncode query
+        { url =
+            flags.config.baseUrl
+                ++ "/api/v1/sec/person?full=true&q="
+                ++ Url.percentEncode query
+                ++ "&sort="
+                ++ Data.PersonOrder.asString order
         , account = getAccount flags
         , expect = Http.expectJson receive Api.Model.PersonList.decoder
         }

--- a/modules/webapp/src/main/elm/Comp/ClassifierSettingsForm.elm
+++ b/modules/webapp/src/main/elm/Comp/ClassifierSettingsForm.elm
@@ -25,6 +25,7 @@ import Data.CalEvent exposing (CalEvent)
 import Data.DropdownStyle as DS
 import Data.Flags exposing (Flags)
 import Data.ListType exposing (ListType)
+import Data.TagOrder
 import Data.UiSettings exposing (UiSettings)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -90,7 +91,7 @@ init flags sett =
             Comp.FixedDropdown.init Data.ListType.all
       }
     , Cmd.batch
-        [ Api.getTags flags "" GetTagsResp
+        [ Api.getTags flags "" Data.TagOrder.NameAsc GetTagsResp
         , Cmd.map ScheduleMsg cec
         ]
     )

--- a/modules/webapp/src/main/elm/Comp/CustomFieldMultiInput.elm
+++ b/modules/webapp/src/main/elm/Comp/CustomFieldMultiInput.elm
@@ -29,6 +29,7 @@ import Api.Model.ItemFieldValue exposing (ItemFieldValue)
 import Comp.CustomFieldInput
 import Comp.FixedDropdown
 import Data.CustomFieldChange exposing (CustomFieldChange(..))
+import Data.CustomFieldOrder
 import Data.CustomFieldType
 import Data.DropdownStyle as DS
 import Data.Flags exposing (Flags)
@@ -116,7 +117,7 @@ init flags =
 
 initCmd : Flags -> Cmd Msg
 initCmd flags =
-    Api.getCustomFields flags "" CustomFieldResp
+    Api.getCustomFields flags "" Data.CustomFieldOrder.LabelAsc CustomFieldResp
 
 
 setValues : List ItemFieldValue -> Msg

--- a/modules/webapp/src/main/elm/Comp/CustomFieldTable.elm
+++ b/modules/webapp/src/main/elm/Comp/CustomFieldTable.elm
@@ -16,8 +16,10 @@ module Comp.CustomFieldTable exposing
 
 import Api.Model.CustomField exposing (CustomField)
 import Comp.Basic as B
+import Data.CustomFieldOrder exposing (CustomFieldOrder)
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import Messages.Comp.CustomFieldTable exposing (Texts)
 import Styles as S
 
@@ -28,6 +30,7 @@ type alias Model =
 
 type Msg
     = EditItem CustomField
+    | ToggleOrder CustomFieldOrder
 
 
 type Action
@@ -35,31 +38,88 @@ type Action
     | EditAction CustomField
 
 
+type Header
+    = Label
+    | Format
+
+
 init : Model
 init =
     {}
 
 
-update : Msg -> Model -> ( Model, Action )
+update : Msg -> Model -> ( Model, Action, Maybe CustomFieldOrder )
 update msg model =
     case msg of
         EditItem item ->
-            ( model, EditAction item )
+            ( model, EditAction item, Nothing )
+
+        ToggleOrder order ->
+            ( model, NoAction, Just order )
+
+
+newOrder : Header -> CustomFieldOrder -> CustomFieldOrder
+newOrder header current =
+    case ( header, current ) of
+        ( Label, Data.CustomFieldOrder.LabelAsc ) ->
+            Data.CustomFieldOrder.LabelDesc
+
+        ( Label, _ ) ->
+            Data.CustomFieldOrder.LabelAsc
+
+        ( Format, Data.CustomFieldOrder.FormatAsc ) ->
+            Data.CustomFieldOrder.FormatDesc
+
+        ( Format, _ ) ->
+            Data.CustomFieldOrder.FormatAsc
 
 
 
 --- View2
 
 
-view2 : Texts -> Model -> List CustomField -> Html Msg
-view2 texts _ items =
+view2 : Texts -> CustomFieldOrder -> Model -> List CustomField -> Html Msg
+view2 texts order _ items =
+    let
+        labelSortIcon =
+            case order of
+                Data.CustomFieldOrder.LabelAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.CustomFieldOrder.LabelDesc ->
+                    "fa fa-sort-alpha-down-alt"
+
+                _ ->
+                    "invisible fa fa-sort-alpha-up"
+
+        formatSortIcon =
+            case order of
+                Data.CustomFieldOrder.FormatAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.CustomFieldOrder.FormatDesc ->
+                    "fa fa-sort-alpha-down-alt"
+
+                _ ->
+                    "invisible fa fa-sort-alpha-up"
+    in
     div []
         [ table [ class S.tableMain ]
             [ thead []
                 [ tr []
                     [ th [] []
-                    , th [ class "text-left" ] [ text texts.nameLabel ]
-                    , th [ class "text-left" ] [ text texts.format ]
+                    , th [ class "text-left" ]
+                        [ a [ href "#", onClick (ToggleOrder <| newOrder Label order) ]
+                            [ i [ class labelSortIcon, class "mr-1" ] []
+                            , text texts.nameLabel
+                            ]
+                        ]
+                    , th [ class "text-left" ]
+                        [ a [ href "#", onClick (ToggleOrder <| newOrder Format order) ]
+                            [ i [ class formatSortIcon, class "mr-1" ] []
+                            , text texts.format
+                            ]
+                        ]
                     , th [ class "text-center hidden sm:table-cell" ] [ text texts.usageCount ]
                     , th [ class "text-center hidden sm:table-cell" ] [ text texts.basics.created ]
                     ]

--- a/modules/webapp/src/main/elm/Comp/EquipmentTable.elm
+++ b/modules/webapp/src/main/elm/Comp/EquipmentTable.elm
@@ -15,10 +15,12 @@ module Comp.EquipmentTable exposing
 
 import Api.Model.Equipment exposing (Equipment)
 import Comp.Basic as B
+import Data.EquipmentOrder exposing (EquipmentOrder)
 import Data.EquipmentUse
 import Data.Flags exposing (Flags)
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import Messages.Comp.EquipmentTable exposing (Texts)
 import Styles as S
 
@@ -40,27 +42,50 @@ type Msg
     = SetEquipments (List Equipment)
     | Select Equipment
     | Deselect
+    | ToggleOrder EquipmentOrder
 
 
-update : Flags -> Msg -> Model -> ( Model, Cmd Msg )
+update : Flags -> Msg -> Model -> ( Model, Cmd Msg, Maybe EquipmentOrder )
 update _ msg model =
     case msg of
         SetEquipments list ->
-            ( { model | equips = list, selected = Nothing }, Cmd.none )
+            ( { model | equips = list, selected = Nothing }, Cmd.none, Nothing )
 
         Select equip ->
-            ( { model | selected = Just equip }, Cmd.none )
+            ( { model | selected = Just equip }, Cmd.none, Nothing )
 
         Deselect ->
-            ( { model | selected = Nothing }, Cmd.none )
+            ( { model | selected = Nothing }, Cmd.none, Nothing )
+
+        ToggleOrder order ->
+            ( model, Cmd.none, Just order )
+
+
+newOrder : EquipmentOrder -> EquipmentOrder
+newOrder current =
+    case current of
+        Data.EquipmentOrder.NameAsc ->
+            Data.EquipmentOrder.NameDesc
+
+        Data.EquipmentOrder.NameDesc ->
+            Data.EquipmentOrder.NameAsc
 
 
 
 --- View2
 
 
-view2 : Texts -> Model -> Html Msg
-view2 texts model =
+view2 : Texts -> EquipmentOrder -> Model -> Html Msg
+view2 texts order model =
+    let
+        nameSortIcon =
+            case order of
+                Data.EquipmentOrder.NameAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.EquipmentOrder.NameDesc ->
+                    "fa fa-sort-alpha-down-alt"
+    in
     table [ class S.tableMain ]
         [ thead []
             [ tr []
@@ -68,7 +93,12 @@ view2 texts model =
                 , th [ class "text-left pr-1 md:px-2 w-20" ]
                     [ text texts.use
                     ]
-                , th [ class "text-left" ] [ text texts.basics.name ]
+                , th [ class "text-left" ]
+                    [ a [ href "#", onClick (ToggleOrder <| newOrder order) ]
+                        [ i [ class nameSortIcon, class "mr-1" ] []
+                        , text texts.basics.name
+                        ]
+                    ]
                 ]
             ]
         , tbody []

--- a/modules/webapp/src/main/elm/Comp/FolderTable.elm
+++ b/modules/webapp/src/main/elm/Comp/FolderTable.elm
@@ -16,8 +16,10 @@ module Comp.FolderTable exposing
 
 import Api.Model.FolderItem exposing (FolderItem)
 import Comp.Basic as B
+import Data.FolderOrder exposing (FolderOrder)
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import Messages.Comp.FolderTable exposing (Texts)
 import Styles as S
 
@@ -28,6 +30,7 @@ type alias Model =
 
 type Msg
     = EditItem FolderItem
+    | ToggleOrder FolderOrder
 
 
 type Action
@@ -35,32 +38,87 @@ type Action
     | EditAction FolderItem
 
 
+type Header
+    = Name
+    | Owner
+
+
 init : Model
 init =
     {}
 
 
-update : Msg -> Model -> ( Model, Action )
+update : Msg -> Model -> ( Model, Action, Maybe FolderOrder )
 update msg model =
     case msg of
         EditItem item ->
-            ( model, EditAction item )
+            ( model, EditAction item, Nothing )
+
+        ToggleOrder order ->
+            ( model, NoAction, Just order )
+
+
+newOrder : Header -> FolderOrder -> FolderOrder
+newOrder header current =
+    case ( header, current ) of
+        ( Name, Data.FolderOrder.NameAsc ) ->
+            Data.FolderOrder.NameDesc
+
+        ( Name, _ ) ->
+            Data.FolderOrder.NameAsc
+
+        ( Owner, Data.FolderOrder.OwnerAsc ) ->
+            Data.FolderOrder.OwnerDesc
+
+        ( Owner, _ ) ->
+            Data.FolderOrder.OwnerAsc
 
 
 
 --- View2
 
 
-view2 : Texts -> Model -> List FolderItem -> Html Msg
-view2 texts _ items =
+view2 : Texts -> FolderOrder -> Model -> List FolderItem -> Html Msg
+view2 texts order _ items =
+    let
+        nameSortIcon =
+            case order of
+                Data.FolderOrder.NameAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.FolderOrder.NameDesc ->
+                    "fa fa-sort-alpha-down-alt"
+
+                _ ->
+                    "invisible fa fa-sort-alpha-up"
+
+        ownerSortIcon =
+            case order of
+                Data.FolderOrder.OwnerAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.FolderOrder.OwnerDesc ->
+                    "fa fa-sort-alpha-down-alt"
+
+                _ ->
+                    "invisible fa fa-sort-alpha-up"
+    in
     table [ class S.tableMain ]
         [ thead []
             [ tr []
                 [ th [ class "w-px whitespace-nowrap pr-1 md:pr-3" ] []
                 , th [ class "text-left" ]
-                    [ text texts.basics.name
+                    [ a [ href "#", onClick (ToggleOrder <| newOrder Name order) ]
+                        [ i [ class nameSortIcon, class "mr-1" ] []
+                        , text texts.basics.name
+                        ]
                     ]
-                , th [ class "text-left hidden sm:table-cell" ] [ text "Owner" ]
+                , th [ class "text-left hidden sm:table-cell" ]
+                    [ a [ href "#", onClick (ToggleOrder <| newOrder Owner order) ]
+                        [ i [ class ownerSortIcon, class "mr-1" ] []
+                        , text texts.owner
+                        ]
+                    ]
                 , th [ class "text-center" ]
                     [ span [ class "hidden sm:inline" ]
                         [ text texts.memberCount

--- a/modules/webapp/src/main/elm/Comp/ItemDetail/MultiEditMenu.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/MultiEditMenu.elm
@@ -35,10 +35,14 @@ import Comp.Tabs as TB
 import Data.CustomFieldChange exposing (CustomFieldChange(..))
 import Data.Direction exposing (Direction)
 import Data.DropdownStyle
+import Data.EquipmentOrder
 import Data.Fields
 import Data.Flags exposing (Flags)
+import Data.FolderOrder
 import Data.Icons as Icons
+import Data.PersonOrder
 import Data.PersonUse
+import Data.TagOrder
 import Data.UiSettings exposing (UiSettings)
 import DatePicker exposing (DatePicker)
 import Html exposing (..)
@@ -157,11 +161,11 @@ loadModel flags =
             Comp.DatePicker.init
     in
     Cmd.batch
-        [ Api.getTags flags "" GetTagsResp
+        [ Api.getTags flags "" Data.TagOrder.NameAsc GetTagsResp
         , Api.getOrgLight flags GetOrgResp
-        , Api.getPersons flags "" GetPersonResp
-        , Api.getEquipments flags "" GetEquipResp
-        , Api.getFolders flags "" False GetFolderResp
+        , Api.getPersons flags "" Data.PersonOrder.NameAsc GetPersonResp
+        , Api.getEquipments flags "" Data.EquipmentOrder.NameAsc GetEquipResp
+        , Api.getFolders flags "" Data.FolderOrder.NameAsc False GetFolderResp
         , Cmd.map CustomFieldMsg (Comp.CustomFieldMultiInput.initCmd flags)
         , Cmd.map ItemDatePickerMsg dpc
         , Cmd.map DueDatePickerMsg dpc

--- a/modules/webapp/src/main/elm/Comp/ItemDetail/Update.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/Update.elm
@@ -59,10 +59,14 @@ import Comp.PersonForm
 import Comp.SentMails
 import Data.CustomFieldChange exposing (CustomFieldChange(..))
 import Data.Direction
+import Data.EquipmentOrder
 import Data.Fields exposing (Field)
 import Data.Flags exposing (Flags)
+import Data.FolderOrder
 import Data.ItemNav exposing (ItemNav)
+import Data.PersonOrder
 import Data.PersonUse
+import Data.TagOrder
 import Data.UiSettings exposing (UiSettings)
 import DatePicker
 import Dict
@@ -265,7 +269,7 @@ update key flags inav settings msg model =
                     , getOptions flags
                     , proposalCmd
                     , Api.getSentMails flags item.id SentMailsResp
-                    , Api.getPersons flags "" GetPersonResp
+                    , Api.getPersons flags "" Data.PersonOrder.NameAsc GetPersonResp
                     , Cmd.map CustomFieldMsg (Comp.CustomFieldMultiInput.initCmd flags)
                     ]
             , sub =
@@ -1642,11 +1646,11 @@ update key flags inav settings msg model =
 getOptions : Flags -> Cmd Msg
 getOptions flags =
     Cmd.batch
-        [ Api.getTags flags "" GetTagsResp
+        [ Api.getTags flags "" Data.TagOrder.NameAsc GetTagsResp
         , Api.getOrgLight flags GetOrgResp
-        , Api.getPersons flags "" GetPersonResp
-        , Api.getEquipments flags "" GetEquipResp
-        , Api.getFolders flags "" False GetFolderResp
+        , Api.getPersons flags "" Data.PersonOrder.NameAsc GetPersonResp
+        , Api.getEquipments flags "" Data.EquipmentOrder.NameAsc GetEquipResp
+        , Api.getFolders flags "" Data.FolderOrder.NameAsc False GetFolderResp
         ]
 
 

--- a/modules/webapp/src/main/elm/Comp/NotificationForm.elm
+++ b/modules/webapp/src/main/elm/Comp/NotificationForm.elm
@@ -30,6 +30,7 @@ import Comp.YesNoDimmer
 import Data.CalEvent exposing (CalEvent)
 import Data.DropdownStyle as DS
 import Data.Flags exposing (Flags)
+import Data.TagOrder
 import Data.UiSettings exposing (UiSettings)
 import Data.Validated exposing (Validated(..))
 import Html exposing (..)
@@ -182,7 +183,7 @@ init flags =
       }
     , Cmd.batch
         [ Api.getMailSettings flags "" ConnResp
-        , Api.getTags flags "" GetTagsResp
+        , Api.getTags flags "" Data.TagOrder.NameAsc GetTagsResp
         , Cmd.map CalEventMsg scmd
         ]
     )

--- a/modules/webapp/src/main/elm/Comp/OrgTable.elm
+++ b/modules/webapp/src/main/elm/Comp/OrgTable.elm
@@ -17,8 +17,10 @@ import Api.Model.Organization exposing (Organization)
 import Comp.Basic as B
 import Data.Flags exposing (Flags)
 import Data.OrgUse
+import Data.OrganizationOrder exposing (OrganizationOrder)
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import Messages.Comp.OrgTable exposing (Texts)
 import Styles as S
 import Util.Address
@@ -42,27 +44,50 @@ type Msg
     = SetOrgs (List Organization)
     | Select Organization
     | Deselect
+    | ToggleOrder OrganizationOrder
 
 
-update : Flags -> Msg -> Model -> ( Model, Cmd Msg )
+update : Flags -> Msg -> Model -> ( Model, Cmd Msg, Maybe OrganizationOrder )
 update _ msg model =
     case msg of
         SetOrgs list ->
-            ( { model | orgs = list, selected = Nothing }, Cmd.none )
+            ( { model | orgs = list, selected = Nothing }, Cmd.none, Nothing )
 
         Select equip ->
-            ( { model | selected = Just equip }, Cmd.none )
+            ( { model | selected = Just equip }, Cmd.none, Nothing )
 
         Deselect ->
-            ( { model | selected = Nothing }, Cmd.none )
+            ( { model | selected = Nothing }, Cmd.none, Nothing )
+
+        ToggleOrder order ->
+            ( model, Cmd.none, Just order )
+
+
+newOrder : OrganizationOrder -> OrganizationOrder
+newOrder current =
+    case current of
+        Data.OrganizationOrder.NameAsc ->
+            Data.OrganizationOrder.NameDesc
+
+        Data.OrganizationOrder.NameDesc ->
+            Data.OrganizationOrder.NameAsc
 
 
 
 --- View2
 
 
-view2 : Texts -> Model -> Html Msg
-view2 texts model =
+view2 : Texts -> OrganizationOrder -> Model -> Html Msg
+view2 texts order model =
+    let
+        nameSortIcon =
+            case order of
+                Data.OrganizationOrder.NameAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.OrganizationOrder.NameDesc ->
+                    "fa fa-sort-alpha-down-alt"
+    in
     table [ class S.tableMain ]
         [ thead []
             [ tr []
@@ -71,7 +96,10 @@ view2 texts model =
                     [ text texts.use
                     ]
                 , th [ class "text-left" ]
-                    [ text texts.basics.name
+                    [ a [ href "#", onClick (ToggleOrder <| newOrder order) ]
+                        [ i [ class nameSortIcon, class "mr-1" ] []
+                        , text texts.basics.name
+                        ]
                     ]
                 , th [ class "text-left hidden md:table-cell" ]
                     [ text texts.address

--- a/modules/webapp/src/main/elm/Comp/PersonTable.elm
+++ b/modules/webapp/src/main/elm/Comp/PersonTable.elm
@@ -16,9 +16,11 @@ module Comp.PersonTable exposing
 import Api.Model.Person exposing (Person)
 import Comp.Basic as B
 import Data.Flags exposing (Flags)
+import Data.PersonOrder exposing (PersonOrder)
 import Data.PersonUse
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import Messages.Comp.PersonTable exposing (Texts)
 import Styles as S
 import Util.Contact
@@ -41,27 +43,75 @@ type Msg
     = SetPersons (List Person)
     | Select Person
     | Deselect
+    | ToggleOrder PersonOrder
 
 
-update : Flags -> Msg -> Model -> ( Model, Cmd Msg )
+update : Flags -> Msg -> Model -> ( Model, Cmd Msg, Maybe PersonOrder )
 update _ msg model =
     case msg of
         SetPersons list ->
-            ( { model | equips = list, selected = Nothing }, Cmd.none )
+            ( { model | equips = list, selected = Nothing }, Cmd.none, Nothing )
 
         Select equip ->
-            ( { model | selected = Just equip }, Cmd.none )
+            ( { model | selected = Just equip }, Cmd.none, Nothing )
 
         Deselect ->
-            ( { model | selected = Nothing }, Cmd.none )
+            ( { model | selected = Nothing }, Cmd.none, Nothing )
+
+        ToggleOrder order ->
+            ( model, Cmd.none, Just order )
+
+
+type Header
+    = Name
+    | Org
+
+
+newOrder : Header -> PersonOrder -> PersonOrder
+newOrder header current =
+    case ( header, current ) of
+        ( Name, Data.PersonOrder.NameAsc ) ->
+            Data.PersonOrder.NameDesc
+
+        ( Name, _ ) ->
+            Data.PersonOrder.NameAsc
+
+        ( Org, Data.PersonOrder.OrgAsc ) ->
+            Data.PersonOrder.OrgDesc
+
+        ( Org, _ ) ->
+            Data.PersonOrder.OrgAsc
 
 
 
 --- View2
 
 
-view2 : Texts -> Model -> Html Msg
-view2 texts model =
+view2 : Texts -> PersonOrder -> Model -> Html Msg
+view2 texts order model =
+    let
+        nameSortIcon =
+            case order of
+                Data.PersonOrder.NameAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.PersonOrder.NameDesc ->
+                    "fa fa-sort-alpha-down-alt"
+
+                _ ->
+                    "invisible fa fa-sort-alpha-down-alt"
+
+        orgSortIcon =
+            case order of
+                Data.PersonOrder.OrgAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.PersonOrder.OrgDesc ->
+                    "fa fa-sort-alpha-down-alt"
+
+                _ ->
+                    "invisible fa fa-sort-alpha-down-alt"
+    in
     table [ class S.tableMain ]
         [ thead []
             [ tr []
@@ -69,8 +119,18 @@ view2 texts model =
                 , th [ class "text-left pr-1 md:px-2" ]
                     [ text texts.use
                     ]
-                , th [ class "text-left" ] [ text texts.basics.name ]
-                , th [ class "text-left hidden sm:table-cell" ] [ text texts.basics.organization ]
+                , th [ class "text-left" ]
+                    [ a [ href "#", onClick (ToggleOrder <| newOrder Name order) ]
+                        [ i [ class nameSortIcon, class "mr-1" ] []
+                        , text texts.basics.name
+                        ]
+                    ]
+                , th [ class "text-left hidden sm:table-cell" ]
+                    [ a [ href "#", onClick (ToggleOrder <| newOrder Org order) ]
+                        [ i [ class orgSortIcon, class "mr-1" ] []
+                        , text texts.basics.organization
+                        ]
+                    ]
                 , th [ class "text-left hidden md:table-cell" ] [ text texts.contact ]
                 ]
             ]

--- a/modules/webapp/src/main/elm/Comp/ScanMailboxForm.elm
+++ b/modules/webapp/src/main/elm/Comp/ScanMailboxForm.elm
@@ -37,7 +37,9 @@ import Data.CalEvent exposing (CalEvent)
 import Data.Direction exposing (Direction(..))
 import Data.DropdownStyle as DS
 import Data.Flags exposing (Flags)
+import Data.FolderOrder
 import Data.Language exposing (Language)
+import Data.TagOrder
 import Data.UiSettings exposing (UiSettings)
 import Data.Validated exposing (Validated(..))
 import Html exposing (..)
@@ -221,8 +223,8 @@ initWith flags s =
         [ Api.getImapSettings flags "" ConnResp
         , nc
         , Cmd.map CalEventMsg sc
-        , Api.getFolders flags "" False GetFolderResp
-        , Api.getTags flags "" GetTagResp
+        , Api.getFolders flags "" Data.FolderOrder.NameAsc False GetFolderResp
+        , Api.getTags flags "" Data.TagOrder.NameAsc GetTagResp
         ]
     )
 
@@ -268,8 +270,8 @@ init flags =
       }
     , Cmd.batch
         [ Api.getImapSettings flags "" ConnResp
-        , Api.getFolders flags "" False GetFolderResp
-        , Api.getTags flags "" GetTagResp
+        , Api.getFolders flags "" Data.FolderOrder.NameAsc False GetFolderResp
+        , Api.getTags flags "" Data.TagOrder.NameAsc GetTagResp
         , Cmd.map CalEventMsg scmd
         ]
     )

--- a/modules/webapp/src/main/elm/Comp/SearchMenu.elm
+++ b/modules/webapp/src/main/elm/Comp/SearchMenu.elm
@@ -40,10 +40,12 @@ import Comp.TagSelect
 import Data.CustomFieldChange exposing (CustomFieldValueCollect)
 import Data.Direction exposing (Direction)
 import Data.DropdownStyle as DS
+import Data.EquipmentOrder
 import Data.EquipmentUse
 import Data.Fields
 import Data.Flags exposing (Flags)
 import Data.ItemQuery as Q exposing (ItemQuery)
+import Data.PersonOrder
 import Data.PersonUse
 import Data.SearchMode exposing (SearchMode)
 import Data.UiSettings exposing (UiSettings)
@@ -441,8 +443,8 @@ updateDrop ddm flags settings msg model =
                 Cmd.batch
                     [ Api.itemSearchStats flags Api.Model.ItemQuery.empty GetAllTagsResp
                     , Api.getOrgLight flags GetOrgResp
-                    , Api.getEquipments flags "" GetEquipResp
-                    , Api.getPersons flags "" GetPersonResp
+                    , Api.getEquipments flags "" Data.EquipmentOrder.NameAsc GetEquipResp
+                    , Api.getPersons flags "" Data.PersonOrder.NameAsc GetPersonResp
                     , Cmd.map CustomFieldMsg (Comp.CustomFieldMultiInput.initCmd flags)
                     , cdp
                     ]
@@ -1088,7 +1090,7 @@ findTab tab =
             Nothing
 
 
-tabLook :UiSettings -> Model -> SearchTab -> Comp.Tabs.Look
+tabLook : UiSettings -> Model -> SearchTab -> Comp.Tabs.Look
 tabLook settings model tab =
     let
         isHidden f =
@@ -1097,6 +1099,7 @@ tabLook settings model tab =
         hiddenOr fields default =
             if List.all isHidden fields then
                 Comp.Tabs.Hidden
+
             else
                 default
 
@@ -1126,41 +1129,41 @@ tabLook settings model tab =
             activeWhen model.inboxCheckbox
 
         TabTags ->
-            hiddenOr [Data.Fields.Tag]
+            hiddenOr [ Data.Fields.Tag ]
                 (activeWhenNotEmpty model.tagSelection.includeTags model.tagSelection.excludeTags)
 
         TabTagCategories ->
-            hiddenOr [Data.Fields.Tag]
+            hiddenOr [ Data.Fields.Tag ]
                 (activeWhenNotEmpty model.tagSelection.includeCats model.tagSelection.excludeCats)
 
         TabFolder ->
-            hiddenOr [Data.Fields.Folder]
+            hiddenOr [ Data.Fields.Folder ]
                 (activeWhenJust model.selectedFolder)
 
         TabCorrespondent ->
-            hiddenOr [Data.Fields.CorrOrg, Data.Fields.CorrPerson] <|
+            hiddenOr [ Data.Fields.CorrOrg, Data.Fields.CorrPerson ] <|
                 activeWhenNotEmpty (Comp.Dropdown.getSelected model.orgModel)
                     (Comp.Dropdown.getSelected model.corrPersonModel)
 
         TabConcerning ->
-            hiddenOr [Data.Fields.ConcPerson, Data.Fields.ConcEquip ] <|
+            hiddenOr [ Data.Fields.ConcPerson, Data.Fields.ConcEquip ] <|
                 activeWhenNotEmpty (Comp.Dropdown.getSelected model.concPersonModel)
                     (Comp.Dropdown.getSelected model.concEquipmentModel)
 
         TabDate ->
-            hiddenOr [Data.Fields.Date] <|
-                activeWhenJust (Util.Maybe.or [model.fromDate, model.untilDate])
+            hiddenOr [ Data.Fields.Date ] <|
+                activeWhenJust (Util.Maybe.or [ model.fromDate, model.untilDate ])
 
         TabDueDate ->
-            hiddenOr [Data.Fields.DueDate] <|
-                activeWhenJust (Util.Maybe.or [model.fromDueDate, model.untilDueDate])
+            hiddenOr [ Data.Fields.DueDate ] <|
+                activeWhenJust (Util.Maybe.or [ model.fromDueDate, model.untilDueDate ])
 
         TabSource ->
-            hiddenOr [Data.Fields.SourceName] <|
+            hiddenOr [ Data.Fields.SourceName ] <|
                 activeWhenJust model.sourceModel
 
         TabDirection ->
-            hiddenOr [Data.Fields.Direction] <|
+            hiddenOr [ Data.Fields.Direction ] <|
                 activeWhenNotEmpty (Comp.Dropdown.getSelected model.directionModel) []
 
         TabTrashed ->
@@ -1179,7 +1182,6 @@ searchTabState settings model tab =
         searchTab =
             findTab tab
 
-
         folded =
             if Set.member tab.name model.openTabs then
                 Comp.Tabs.Open
@@ -1189,10 +1191,10 @@ searchTabState settings model tab =
 
         state =
             { folded = folded
-            , look =  Maybe.map (tabLook settings model) searchTab
-                      |> Maybe.withDefault Comp.Tabs.Normal
+            , look =
+                Maybe.map (tabLook settings model) searchTab
+                    |> Maybe.withDefault Comp.Tabs.Normal
             }
-
     in
     ( state, ToggleAkkordionTab tab.name )
 

--- a/modules/webapp/src/main/elm/Comp/SourceForm.elm
+++ b/modules/webapp/src/main/elm/Comp/SourceForm.elm
@@ -27,8 +27,10 @@ import Comp.Dropdown exposing (isDropdownChangeMsg)
 import Comp.FixedDropdown
 import Data.DropdownStyle as DS
 import Data.Flags exposing (Flags)
+import Data.FolderOrder
 import Data.Language exposing (Language)
 import Data.Priority exposing (Priority)
+import Data.TagOrder
 import Data.UiSettings exposing (UiSettings)
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -89,8 +91,8 @@ init : Flags -> ( Model, Cmd Msg )
 init flags =
     ( emptyModel
     , Cmd.batch
-        [ Api.getFolders flags "" False GetFolderResp
-        , Api.getTags flags "" GetTagResp
+        [ Api.getFolders flags "" Data.FolderOrder.NameAsc False GetFolderResp
+        , Api.getTags flags "" Data.TagOrder.NameAsc GetTagResp
         ]
     )
 

--- a/modules/webapp/src/main/elm/Comp/TagTable.elm
+++ b/modules/webapp/src/main/elm/Comp/TagTable.elm
@@ -16,8 +16,10 @@ module Comp.TagTable exposing
 import Api.Model.Tag exposing (Tag)
 import Comp.Basic as B
 import Data.Flags exposing (Flags)
+import Data.TagOrder exposing (TagOrder)
 import Html exposing (..)
 import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
 import Messages.Comp.TagTable exposing (Texts)
 import Styles as S
 
@@ -35,37 +37,108 @@ emptyModel =
     }
 
 
+type Header
+    = Name
+    | Category
+
+
 type Msg
     = SetTags (List Tag)
     | Select Tag
     | Deselect
+    | SortClick TagOrder
 
 
-update : Flags -> Msg -> Model -> ( Model, Cmd Msg )
+update : Flags -> Msg -> Model -> ( Model, Cmd Msg, Maybe TagOrder )
 update _ msg model =
     case msg of
         SetTags list ->
-            ( { model | tags = list, selected = Nothing }, Cmd.none )
+            ( { model | tags = list, selected = Nothing }, Cmd.none, Nothing )
 
         Select tag ->
-            ( { model | selected = Just tag }, Cmd.none )
+            ( { model | selected = Just tag }, Cmd.none, Nothing )
 
         Deselect ->
-            ( { model | selected = Nothing }, Cmd.none )
+            ( { model | selected = Nothing }, Cmd.none, Nothing )
+
+        SortClick order ->
+            ( model, Cmd.none, Just order )
+
+
+newOrder : Header -> TagOrder -> TagOrder
+newOrder header current =
+    case ( header, current ) of
+        ( Name, Data.TagOrder.NameAsc ) ->
+            Data.TagOrder.NameDesc
+
+        ( Name, Data.TagOrder.NameDesc ) ->
+            Data.TagOrder.NameAsc
+
+        ( Name, Data.TagOrder.CategoryAsc ) ->
+            Data.TagOrder.NameAsc
+
+        ( Name, Data.TagOrder.CategoryDesc ) ->
+            Data.TagOrder.NameAsc
+
+        ( Category, Data.TagOrder.NameAsc ) ->
+            Data.TagOrder.CategoryAsc
+
+        ( Category, Data.TagOrder.NameDesc ) ->
+            Data.TagOrder.CategoryAsc
+
+        ( Category, Data.TagOrder.CategoryAsc ) ->
+            Data.TagOrder.CategoryDesc
+
+        ( Category, Data.TagOrder.CategoryDesc ) ->
+            Data.TagOrder.CategoryAsc
 
 
 
 --- View2
 
 
-view2 : Texts -> Model -> Html Msg
-view2 texts model =
+view2 : Texts -> TagOrder -> Model -> Html Msg
+view2 texts order model =
+    let
+        nameSortIcon =
+            case order of
+                Data.TagOrder.NameAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.TagOrder.NameDesc ->
+                    "fa fa-sort-alpha-down-alt"
+
+                _ ->
+                    "invisible fa fa-sort-alpha-down"
+
+        catSortIcon =
+            case order of
+                Data.TagOrder.CategoryAsc ->
+                    "fa fa-sort-alpha-up"
+
+                Data.TagOrder.CategoryDesc ->
+                    "fa fa-sort-alpha-down-alt"
+
+                _ ->
+                    "invisible fa fa-sort-alpha-down"
+    in
     table [ class S.tableMain ]
         [ thead []
             [ tr []
                 [ th [ class "" ] []
-                , th [ class "text-left" ] [ text texts.basics.name ]
-                , th [ class "text-left" ] [ text texts.category ]
+                , th [ class "text-left" ]
+                    [ a [ href "#", onClick (SortClick <| newOrder Name order) ]
+                        [ i [ class nameSortIcon, class "mr-1" ] []
+                        , text texts.basics.name
+                        ]
+                    ]
+                , th [ class "text-left" ]
+                    [ a [ href "#", onClick (SortClick <| newOrder Category order) ]
+                        [ i [ class catSortIcon, class "mr-1" ]
+                            []
+                        , text texts.category
+                        ]
+                    ]
                 ]
             ]
         , tbody []

--- a/modules/webapp/src/main/elm/Comp/UiSettingsForm.elm
+++ b/modules/webapp/src/main/elm/Comp/UiSettingsForm.elm
@@ -28,6 +28,7 @@ import Data.DropdownStyle as DS
 import Data.Fields exposing (Field)
 import Data.Flags exposing (Flags)
 import Data.ItemTemplate as IT exposing (ItemTemplate)
+import Data.TagOrder
 import Data.UiSettings exposing (ItemPattern, Pos(..), UiSettings)
 import Dict exposing (Dict)
 import Html exposing (..)
@@ -160,7 +161,7 @@ init flags settings =
             Comp.FixedDropdown.init Messages.UiLanguage.all
       , openTabs = Set.empty
       }
-    , Api.getTags flags "" GetTagsResp
+    , Api.getTags flags "" Data.TagOrder.NameAsc GetTagsResp
     )
 
 

--- a/modules/webapp/src/main/elm/Data/CustomFieldOrder.elm
+++ b/modules/webapp/src/main/elm/Data/CustomFieldOrder.elm
@@ -1,0 +1,31 @@
+{-
+   Copyright 2020 Docspell Contributors
+
+   SPDX-License-Identifier: GPL-3.0-or-later
+-}
+
+
+module Data.CustomFieldOrder exposing (CustomFieldOrder(..), asString)
+
+
+type CustomFieldOrder
+    = LabelAsc
+    | LabelDesc
+    | FormatAsc
+    | FormatDesc
+
+
+asString : CustomFieldOrder -> String
+asString order =
+    case order of
+        LabelAsc ->
+            "label"
+
+        LabelDesc ->
+            "-label"
+
+        FormatAsc ->
+            "type"
+
+        FormatDesc ->
+            "-type"

--- a/modules/webapp/src/main/elm/Data/EquipmentOrder.elm
+++ b/modules/webapp/src/main/elm/Data/EquipmentOrder.elm
@@ -1,0 +1,23 @@
+{-
+   Copyright 2020 Docspell Contributors
+
+   SPDX-License-Identifier: GPL-3.0-or-later
+-}
+
+
+module Data.EquipmentOrder exposing (EquipmentOrder(..), asString)
+
+
+type EquipmentOrder
+    = NameAsc
+    | NameDesc
+
+
+asString : EquipmentOrder -> String
+asString order =
+    case order of
+        NameAsc ->
+            "name"
+
+        NameDesc ->
+            "-name"

--- a/modules/webapp/src/main/elm/Data/FolderOrder.elm
+++ b/modules/webapp/src/main/elm/Data/FolderOrder.elm
@@ -1,0 +1,31 @@
+{-
+   Copyright 2020 Docspell Contributors
+
+   SPDX-License-Identifier: GPL-3.0-or-later
+-}
+
+
+module Data.FolderOrder exposing (FolderOrder(..), asString)
+
+
+type FolderOrder
+    = NameAsc
+    | NameDesc
+    | OwnerAsc
+    | OwnerDesc
+
+
+asString : FolderOrder -> String
+asString order =
+    case order of
+        NameAsc ->
+            "name"
+
+        NameDesc ->
+            "-name"
+
+        OwnerAsc ->
+            "owner"
+
+        OwnerDesc ->
+            "-owner"

--- a/modules/webapp/src/main/elm/Data/OrganizationOrder.elm
+++ b/modules/webapp/src/main/elm/Data/OrganizationOrder.elm
@@ -1,0 +1,23 @@
+{-
+   Copyright 2020 Docspell Contributors
+
+   SPDX-License-Identifier: GPL-3.0-or-later
+-}
+
+
+module Data.OrganizationOrder exposing (OrganizationOrder(..), asString)
+
+
+type OrganizationOrder
+    = NameAsc
+    | NameDesc
+
+
+asString : OrganizationOrder -> String
+asString order =
+    case order of
+        NameAsc ->
+            "name"
+
+        NameDesc ->
+            "-name"

--- a/modules/webapp/src/main/elm/Data/PersonOrder.elm
+++ b/modules/webapp/src/main/elm/Data/PersonOrder.elm
@@ -1,0 +1,31 @@
+{-
+   Copyright 2020 Docspell Contributors
+
+   SPDX-License-Identifier: GPL-3.0-or-later
+-}
+
+
+module Data.PersonOrder exposing (PersonOrder(..), asString)
+
+
+type PersonOrder
+    = NameAsc
+    | NameDesc
+    | OrgAsc
+    | OrgDesc
+
+
+asString : PersonOrder -> String
+asString order =
+    case order of
+        NameAsc ->
+            "name"
+
+        NameDesc ->
+            "-name"
+
+        OrgAsc ->
+            "org"
+
+        OrgDesc ->
+            "-org"

--- a/modules/webapp/src/main/elm/Data/TagOrder.elm
+++ b/modules/webapp/src/main/elm/Data/TagOrder.elm
@@ -1,0 +1,31 @@
+{-
+   Copyright 2020 Docspell Contributors
+
+   SPDX-License-Identifier: GPL-3.0-or-later
+-}
+
+
+module Data.TagOrder exposing (TagOrder(..), asString)
+
+
+type TagOrder
+    = NameAsc
+    | NameDesc
+    | CategoryAsc
+    | CategoryDesc
+
+
+asString : TagOrder -> String
+asString order =
+    case order of
+        NameAsc ->
+            "name"
+
+        NameDesc ->
+            "-name"
+
+        CategoryAsc ->
+            "category"
+
+        CategoryDesc ->
+            "-category"

--- a/modules/webapp/src/main/elm/Messages/Comp/FolderTable.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/FolderTable.elm
@@ -20,6 +20,7 @@ type alias Texts =
     { basics : Messages.Basics.Texts
     , memberCount : String
     , formatDateShort : Int -> String
+    , owner : String
     }
 
 
@@ -28,6 +29,7 @@ gb =
     { basics = Messages.Basics.gb
     , memberCount = "#Member"
     , formatDateShort = DF.formatDateShort Messages.UiLanguage.English
+    , owner = "Owner"
     }
 
 
@@ -36,4 +38,5 @@ de =
     { basics = Messages.Basics.de
     , memberCount = "#Mitglieder"
     , formatDateShort = DF.formatDateShort Messages.UiLanguage.German
+    , owner = "Besitzer"
     }


### PR DESCRIPTION
The query now searches in more fields. For example, when getting a
list of tags, the query is applied to the tag name *and* category.
When listing persons, the query now also looks in the associated
organization name.

This has been used to make some headers in the meta data tables
clickable to sort the list accordingly.

Closes: #965 
Closes: #538