### PR TITLE
Reduce startup command length

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -547,7 +547,13 @@ val webapp = project
 
 val joex = project
   .in(file("modules/joex"))
-  .enablePlugins(BuildInfoPlugin, JavaServerAppPackaging, DebianPlugin, SystemdPlugin)
+  .enablePlugins(
+    BuildInfoPlugin,
+    JavaServerAppPackaging,
+    DebianPlugin,
+    SystemdPlugin,
+    ClasspathJarPlugin
+  )
   .settings(sharedSettings)
   .settings(testSettingsMUnit)
   .settings(debianSettings("docspell-joex"))
@@ -586,7 +592,13 @@ val joex = project
 
 val restserver = project
   .in(file("modules/restserver"))
-  .enablePlugins(BuildInfoPlugin, JavaServerAppPackaging, DebianPlugin, SystemdPlugin)
+  .enablePlugins(
+    BuildInfoPlugin,
+    JavaServerAppPackaging,
+    DebianPlugin,
+    SystemdPlugin,
+    ClasspathJarPlugin
+  )
   .settings(sharedSettings)
   .settings(testSettingsMUnit)
   .settings(debianSettings("docspell-server"))


### PR DESCRIPTION
The start scripts contain a huge command that may cause problems on
some systems, reportedly at windows. The ClasspathJarPlugin can
mitigate this by creating a tiny jar that only contains the classpath
of the app.

https://sbt-native-packager.readthedocs.io/en/stable/recipes/longclasspath.html#generate-a-classpath-jar