### PR TITLE
Don't allow shares with fulltext queries

### DIFF
--- a/modules/restserver/src/main/scala/docspell/restserver/routes/ShareRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/ShareRoutes.scala
@@ -130,6 +130,12 @@ object ShareRoutes {
           "Share not found or not owner. Only the owner can update a share.",
           Ident.unsafe("")
         )
+      case OShare.ChangeResult.QueryWithFulltext =>
+        IdResult(
+          false,
+          "Sorry, shares with fulltext queries are currently not supported.",
+          Ident.unsafe("")
+        )
     }
 
   def mkBasicResult(r: OShare.ChangeResult, msg: => String): BasicResult =
@@ -141,6 +147,11 @@ object ShareRoutes {
         BasicResult(
           false,
           "Share not found or not owner. Only the owner can update a share."
+        )
+      case OShare.ChangeResult.QueryWithFulltext =>
+        BasicResult(
+          false,
+          "Sorry, shares with fulltext queries are currently not supported."
         )
     }
 

--- a/website/site/content/docs/webapp/share.md
+++ b/website/site/content/docs/webapp/share.md
@@ -61,6 +61,11 @@ needs access to it, for example if you want to share all your tax
 documents with the company/person who helps you with doing you tax
 submission.
 
+## Limitations
+
+Currently, shares that contain fulltext search queries are not
+supported. The query for a share must not use any fulltext search.
+
 # Creating shares
 
 There are the following ways to create a share:


### PR DESCRIPTION
Currently the query implementation cannot combine multiple/nested
fulltext searches within a query. It doesn't seem useful to have
shares based on fulltext searches, so it is disabled for now.

Issue: #446