### PR TITLE
Fix sending notification mails from background tasks

### DIFF
--- a/modules/joex/src/main/scala/docspell/joex/notify/PeriodicDueItemsTask.scala
+++ b/modules/joex/src/main/scala/docspell/joex/notify/PeriodicDueItemsTask.scala
@@ -7,6 +7,7 @@
 package docspell.joex.notify
 
 import cats.data.NonEmptyList
+import cats.data.OptionT
 import cats.effect._
 import cats.implicits._
 
@@ -23,6 +24,7 @@ import docspell.query.ItemQueryDsl._
 import docspell.store.qb.Batch
 import docspell.store.queries.ListItem
 import docspell.store.queries.{QItem, Query}
+import docspell.store.records.RUser
 
 object PeriodicDueItemsTask {
   val taskName = PeriodicDueItemsArgs.taskName
@@ -49,7 +51,11 @@ object PeriodicDueItemsTask {
   def withChannel[F[_]: Sync](ctx: Context[F, Args], ops: ONotification[F])(
       cont: Vector[NotificationChannel] => F[Unit]
   ): F[Unit] =
-    TaskOperations.withChannel(ctx.logger, ctx.args.channel, ops)(cont)
+    OptionT(ctx.store.transact(RUser.findIdByAccount(ctx.args.account)))
+      .semiflatMap(userId =>
+        TaskOperations.withChannel(ctx.logger, ctx.args.channel, userId, ops)(cont)
+      )
+      .getOrElse(())
 
   def withItems[F[_]: Sync](ctx: Context[F, Args], limit: Int, now: Timestamp)(
       cont: Vector[ListItem] => F[Unit]

--- a/modules/joex/src/main/scala/docspell/joex/notify/TaskOperations.scala
+++ b/modules/joex/src/main/scala/docspell/joex/notify/TaskOperations.scala
@@ -24,12 +24,13 @@ trait TaskOperations {
   def withChannel[F[_]: Sync](
       logger: Logger[F],
       channel: ChannelOrRef,
+      userId: Ident,
       ops: ONotification[F]
   )(
       cont: Vector[NotificationChannel] => F[Unit]
   ): F[Unit] = {
     val channels = channel match {
-      case Right(ch) => ops.mkNotificationChannel(ch)
+      case Right(ch) => ops.mkNotificationChannel(ch, userId)
       case Left(ref) => ops.findNotificationChannel(ref)
     }
     channels.flatMap { ch =>


### PR DESCRIPTION
When looking up the mail settings, a valid user id must be given.

Fixes: #1229 