### PR TITLE
Add a recursive mail folder scan option to ScanMailboxTask

### DIFF
--- a/modules/common/src/main/scala/docspell/common/ScanMailboxArgs.scala
+++ b/modules/common/src/main/scala/docspell/common/ScanMailboxArgs.scala
@@ -24,7 +24,7 @@ case class ScanMailboxArgs(
     // the configured imap connection
     imapConnection: Ident,
     // scan folders recursively
-    scanRecursively: Boolean,
+    scanRecursively: Option[Boolean],
     // what folders to search
     folders: List[String],
     // only select mails received since then

--- a/modules/common/src/main/scala/docspell/common/ScanMailboxArgs.scala
+++ b/modules/common/src/main/scala/docspell/common/ScanMailboxArgs.scala
@@ -23,6 +23,8 @@ case class ScanMailboxArgs(
     account: AccountId,
     // the configured imap connection
     imapConnection: Ident,
+    // scan folders recursively
+    scanRecursively: Boolean,
     // what folders to search
     folders: List[String],
     // only select mails received since then

--- a/modules/joex/src/main/scala/docspell/joex/scanmailbox/ScanMailboxTask.scala
+++ b/modules/joex/src/main/scala/docspell/joex/scanmailbox/ScanMailboxTask.scala
@@ -98,7 +98,7 @@ object ScanMailboxTask {
       if (acc.noneLeft(name)) acc.pure[F]
       else
         mailer
-          .run(impl.handleFolder(theEmil.access, upload)(name, ctx.args.scanRecursively))
+          .run(impl.handleFolder(theEmil.access, upload)(name, ctx.args.scanRecursively.getOrElse(false)))
           .map(_ ++ acc)
 
     Stream

--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -6407,6 +6407,7 @@ components:
       required:
         - id
         - enabled
+        - scanRecursively
         - imapConnection
         - schedule
         - folders
@@ -6426,6 +6427,10 @@ components:
           type: array
           items:
             type: string
+        scanRecursively:
+          type: boolean
+          description: |
+            Scan folders recursively for new mails.
         schedule:
           type: string
           format: calevent

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/ScanMailboxRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/ScanMailboxRoutes.scala
@@ -115,6 +115,7 @@ object ScanMailboxRoutes {
         ScanMailboxArgs(
           user,
           settings.imapConnection,
+          settings.scanRecursively,
           settings.folders,
           settings.receivedSinceHours.map(_.toLong).map(Duration.hours),
           settings.targetFolder,
@@ -150,6 +151,7 @@ object ScanMailboxRoutes {
       task.summary,
       conn.getOrElse(Ident.unsafe("")),
       task.args.folders,
+      task.args.scanRecursively,
       task.timer,
       task.args.receivedSince.map(_.hours.toInt),
       task.args.targetFolder,

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/ScanMailboxRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/ScanMailboxRoutes.scala
@@ -115,7 +115,7 @@ object ScanMailboxRoutes {
         ScanMailboxArgs(
           user,
           settings.imapConnection,
-          settings.scanRecursively,
+          Option(settings.scanRecursively),
           settings.folders,
           settings.receivedSinceHours.map(_.toLong).map(Duration.hours),
           settings.targetFolder,
@@ -151,7 +151,7 @@ object ScanMailboxRoutes {
       task.summary,
       conn.getOrElse(Ident.unsafe("")),
       task.args.folders,
-      task.args.scanRecursively,
+      task.args.scanRecursively.getOrElse(false),
       task.timer,
       task.args.receivedSince.map(_.hours.toInt),
       task.args.targetFolder,

--- a/modules/webapp/src/main/elm/Comp/ScanMailboxForm.elm
+++ b/modules/webapp/src/main/elm/Comp/ScanMailboxForm.elm
@@ -68,6 +68,7 @@ type alias Model =
     , targetFolder : Maybe String
     , foldersModel : Comp.StringListInput.Model
     , folders : List String
+    , scanRecursively : Bool
     , direction : Maybe Direction
     , schedule : Maybe CalEvent
     , scheduleModel : Comp.CalEventInput.Model
@@ -156,6 +157,7 @@ type Msg
     | ReceivedHoursMsg Comp.IntField.Msg
     | SetTargetFolder String
     | FoldersMsg Comp.StringListInput.Msg
+    | ToggleScanRecursively
     | DirectionMsg (Maybe Direction)
     | YesNoDeleteMsg Comp.YesNoDimmer.Msg
     | GetFolderResp (Result Http.Error FolderList)
@@ -200,6 +202,7 @@ initWith flags s =
         , receivedHours = s.receivedSinceHours
         , targetFolder = s.targetFolder
         , folders = s.folders
+        , scanRecursively = s.scanRecursively
         , schedule = Just newSchedule
         , direction = Maybe.andThen Data.Direction.fromString s.direction
         , scheduleModel = sm
@@ -246,6 +249,7 @@ init flags =
       , receivedHoursModel = Comp.IntField.init (Just 1) Nothing True
       , foldersModel = Comp.StringListInput.init
       , folders = []
+      , scanRecursively = False
       , targetFolder = Nothing
       , direction = Nothing
       , schedule = Just initialSchedule
@@ -316,6 +320,7 @@ makeSettings model =
                 , deleteMail = model.deleteMail
                 , targetFolder = model.targetFolder
                 , folders = folders
+                , scanRecursively = model.scanRecursively
                 , direction = Maybe.map Data.Direction.asString model.direction
                 , schedule = Data.CalEvent.makeEvent timer
                 , itemFolder = model.itemFolderId
@@ -493,6 +498,12 @@ update flags tz msg model =
                 | foldersModel = fm
                 , folders = newList
               }
+            , NoAction
+            , Cmd.none
+            )
+
+        ToggleScanRecursively ->
+            ( { model | scanRecursively = not model.scanRecursively }
             , NoAction
             , Cmd.none
             )
@@ -961,6 +972,17 @@ viewGeneral2 texts settings model =
 viewProcessing2 : Texts -> Model -> List (Html Msg)
 viewProcessing2 texts model =
     [ div [ class "mb-4" ]
+        [ MB.viewItem <|
+            MB.Checkbox
+                { id = "scanmail-scan-recursively"
+                , value = model.scanRecursively
+                , label = texts.scanRecursivelyLabel
+                , tagger = \_ -> ToggleScanRecursively
+                }
+            , span [ class "opacity-50 text-sm mt-1" ]
+            [ Markdown.toHtml [] texts.scanRecursivelyInfo ]
+        ]
+    , div [ class "mb-4" ]
         [ label [ class S.inputLabel ]
             [ text texts.folders
             , B.inputRequired

--- a/modules/webapp/src/main/elm/Messages/Comp/ScanMailboxForm.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/ScanMailboxForm.elm
@@ -317,7 +317,7 @@ fr tz =
     , documentLanguageInfo =
         "Utilisé pour l'extraction et l'analyse du texte. La langue"
             ++ "par défaut du groupe est utilisée, si non spécifié"
-    , scanRecursivelyInfo = "Recherchez également les courriels dans les sous-dossiers des dossiers donnés."
+    , scanRecursivelyInfo = "Rechercher également les mails dans les sous-dossiers des dossiers spécifiés."
     , scanRecursivelyLabel = "Analyse récursive des dossiers"
     , schedule = "Programmation"
     , scheduleClickForHelp = "Cliquer pour l'aide"

--- a/modules/webapp/src/main/elm/Messages/Comp/ScanMailboxForm.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/ScanMailboxForm.elm
@@ -68,6 +68,8 @@ type alias Texts =
     , tagsInfo : String
     , documentLanguage : String
     , documentLanguageInfo : String
+    , scanRecursivelyInfo : String
+    , scanRecursivelyLabel : String
     , schedule : String
     , scheduleClickForHelp : String
     , scheduleInfo : String
@@ -149,6 +151,8 @@ gb tz =
     , documentLanguageInfo =
         "Used for text extraction and text analysis. The "
             ++ "collective's default language is used, if not specified here."
+    , scanRecursivelyInfo = "Scan the sub-folders of the given folders for emails too."
+    , scanRecursivelyLabel = "Scan folders recursively"
     , schedule = "Schedule"
     , scheduleClickForHelp = "Click here for help"
     , scheduleInfo =
@@ -229,6 +233,8 @@ kann hier ein Wert für alle festgelegt werden. Bei 'Automatisch' wird auf den S
     , documentLanguageInfo =
         "Wird für Texterkennung und -analyse verwendet. Die Standardsprache des Kollektivs "
             ++ "wird verwendet, falls hier nicht angegeben."
+    , scanRecursivelyInfo = "Auch die Unterordner der gegebenen Ordner nach E-Mails durchsuchen."
+    , scanRecursivelyLabel = "Ordner rekursiv scannen"
     , schedule = "Zeitplan"
     , scheduleClickForHelp = "Klicke für Hilfe"
     , scheduleInfo =

--- a/modules/webapp/src/main/elm/Messages/Comp/ScanMailboxForm.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/ScanMailboxForm.elm
@@ -317,6 +317,8 @@ fr tz =
     , documentLanguageInfo =
         "Utilisé pour l'extraction et l'analyse du texte. La langue"
             ++ "par défaut du groupe est utilisée, si non spécifié"
+    , scanRecursivelyInfo = "Recherchez également les courriels dans les sous-dossiers des dossiers donnés."
+    , scanRecursivelyLabel = "Analyse récursive des dossiers"
     , schedule = "Programmation"
     , scheduleClickForHelp = "Cliquer pour l'aide"
     , scheduleInfo =


### PR DESCRIPTION
We have now tried implementing a first version for recursive mailbox scanning.
At the moment, it is controlled by a new checkbox in the Scan Mailbox Task settings.
This depends on our changes to emil (https://github.com/eikek/emil/pull/293), but from our tests, it seems to work quite nicely now.

One problem we have left is how to handle database migration. The JSON parameters for scan-mailbox tasks is stored in a text field in the database, so adding a new "scanRecursively: false" parameter is probably not an option.
We thought the next logical thing was to simply make the new `scanRecursively` parameter optional, with a default value of false (previous behavior) - but that didn't work either, because then the JSON decoder complained that the field was missing. (Apparently, optional only means that it can be `null`, but can not be simply missing...)