### PR TITLE
Disable "group by month" option when there is only one group

### DIFF
--- a/modules/webapp/src/main/elm/Page/Home/View2.elm
+++ b/modules/webapp/src/main/elm/Page/Home/View2.elm
@@ -326,7 +326,7 @@ defaultMenuBar texts flags settings model =
 
                             else
                                 i [ class "fa fa-square font-thin" ] []
-                      , disabled = False
+                      , disabled = List.length model.itemListModel.results.groups <= 1
                       , label = texts.showItemGroups
                       , attrs =
                             [ href "#"


### PR DESCRIPTION
When fulltext search is used, there only is one group. It also doesn't
make much sense when there is just one month group as well.

Closes: #1255 