### PR TITLE
Fixed typo

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - solr-precreate
       - docspell
     healthcheck:
-      test: ["CMD", "curl", "f", "http://localhost:8983/solr/docspell/admin/ping"]
+      test: ["CMD", "curl", "-f", "http://localhost:8983/solr/docspell/admin/ping"]
       interval: 1m
       timeout: 10s
       retries: 2


### PR DESCRIPTION
The missing dash resulted in solr sending a DNS query each minute that returned NxDomain.
In my case they looked like this: "f.base.domain" with base.domain being the base domain set for local DNS.