### PR TITLE
Use iframe for cross-browser pdf view (pdfjs)

### DIFF
--- a/modules/webapp/src/main/elm/Comp/ItemDetail/SingleAttachment.elm
+++ b/modules/webapp/src/main/elm/Comp/ItemDetail/SingleAttachment.elm
@@ -85,12 +85,12 @@ view texts flags settings model pos attach =
                 , style "max-height" "calc(100vh - 140px)"
                 , style "min-height" "500px"
                 ]
-                [ embed
-                    [ src <| Data.UiSettings.pdfUrl settings flags fileUrl
-                    , class "absolute h-full w-full top-0 left-0 mx-0 py-0"
+                [ Data.UiSettings.pdfView settings
+                    flags
+                    fileUrl
+                    [ class "absolute h-full w-full top-0 left-0 mx-0 py-0"
                     , id "ds-pdf-view-iframe"
                     ]
-                    []
                 ]
         ]
 

--- a/modules/webapp/src/main/elm/Data/UiSettings.elm
+++ b/modules/webapp/src/main/elm/Data/UiSettings.elm
@@ -24,6 +24,7 @@ module Data.UiSettings exposing
     , merge
     , mergeDefaults
     , pdfUrl
+    , pdfView
     , storedUiSettingsDecoder
     , storedUiSettingsEncode
     , tagColor
@@ -41,8 +42,8 @@ import Data.ItemTemplate exposing (ItemTemplate)
 import Data.Pdf exposing (PdfMode)
 import Data.UiTheme exposing (UiTheme)
 import Dict exposing (Dict)
-import Html exposing (Attribute)
-import Html.Attributes as HA
+import Html exposing (Attribute, Html, embed, iframe)
+import Html.Attributes as HA exposing (src)
 import Json.Decode as Decode
 import Json.Decode.Pipeline as P
 import Json.Encode as Encode
@@ -424,6 +425,33 @@ pdfUrl settings flags originalUrl =
 
         Data.Pdf.Server ->
             Data.Pdf.serverUrl originalUrl
+
+
+pdfView : UiSettings -> Flags -> String -> List (Attribute msg) -> Html msg
+pdfView settings flags originalUrl attrs =
+    let
+        url =
+            pdfUrl settings flags originalUrl
+
+        native =
+            embed (src url :: attrs) []
+
+        fallback =
+            iframe (src url :: attrs) []
+    in
+    case settings.pdfMode of
+        Data.Pdf.Detect ->
+            if flags.pdfSupported then
+                native
+
+            else
+                fallback
+
+        Data.Pdf.Native ->
+            native
+
+        Data.Pdf.Server ->
+            fallback
 
 
 getUiLanguage : Flags -> UiSettings -> UiLanguage -> UiLanguage


### PR DESCRIPTION
Since some browsers (safari and some mobile ones) don't update their
ui when the src attribute of an embed element changes, an iframe is
used now. But only for the "cross browser" variant.

Fixes: #1210