### PR TITLE
Source generation build fix with backslash file-separator

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -364,7 +364,8 @@ val files = project
       val files = (base ** (_.isFile)).pair(sbt.io.Path.relativeTo(base))
       val lines = files.toList.map(_._2).map { s =>
         val ident = s.replaceAll("[^a-zA-Z0-9_]+", "_")
-        ident -> s"""val $ident = createUrl("$s")"""
+        val sanitized = s.replace('\\', '/')
+        ident -> s"""val $ident = createUrl("$sanitized")"""
       }
       val content = s"""package docspell.files
 


### PR DESCRIPTION
A very small fix to change an accidentally generated Windows file separator ("\\") to a generic file-separator for resources ("/") to avoid malformed String escapes.