### PR TITLE
Build: Fix shell script run under Windows OS

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -999,8 +999,7 @@ def compileElm(
   val cmd = (Seq("elm", "make")
     ++ mode.flags
     ++ Seq("--output", target.toString)
-    ++ Seq(wd / "src" / "main" / "elm" / "Main.elm").map(_.toString)
-    )
+    ++ Seq(wd / "src" / "main" / "elm" / "Main.elm").map(_.toString))
   Cmd.run(cmd, wd, logger)
   val targetGZ = file(target.toString + ".gz")
   IO.gzip(target, targetGZ)

--- a/project/Cmd.scala
+++ b/project/Cmd.scala
@@ -25,7 +25,8 @@ object Cmd {
   def exec(cmd: Seq[String], wd: Option[File]): Result = {
     val command =
       sys.props.get("os.name") match {
-        case Some(name) if name.toLowerCase.startsWith("windows") => Seq ("cmd", "/C") ++ cmd
+        case Some(name) if name.toLowerCase.startsWith("windows") =>
+          Seq("cmd", "/C") ++ cmd
         case _ => cmd
       }
     val capt = new Capture


### PR DESCRIPTION
A small fix up that allows almost all `sbt make(-*)` commands to run under Windows (except `sbt make-deb`, as a workaround a dev should use a Linux subsystem). There is also a small refactoring included to call Elm now also via `Cmd.run`.

I checked in parallel to use `JDebPackaging` instead of `DebianPlugin` but I faced a bug in the JDebPackaging (maybe a bug in the plugin or in the config). I postpone this adjustment until I have found a solution for it. Because then the complete build would be possible under Windows.