### PR TITLE
Include limit-capped flag with search response

### DIFF
--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -8591,11 +8591,33 @@ components:
         A list of item details.
       required:
         - groups
+        - limit
+        - offset
+        - limitCapped
       properties:
         groups:
           type: array
           items:
             $ref: "#/components/schemas/ItemLightGroup"
+        limit:
+          type: integer
+          format: int32
+          description: |
+            Returns the `limit` value as used for this search. This
+            can deviate from the requested limit, if it exceeds the
+            server defined maximum. See `limitCapped`.
+        offset:
+          type: integer
+          format: int32
+          description: |
+            The `offset` value used for this search.
+        limitCapped:
+          type: boolean
+          description: |
+            The server defines a maximum `limit` value. If the
+            requested `limit` exceeds the server defined one, this
+            flag is set to true. The limit used for the query is
+            returned with this response.
     ItemLightGroup:
       description: |
         A group of items.

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/ShareSearchRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/ShareSearchRoutes.scala
@@ -51,6 +51,7 @@ object ShareSearchRoutes {
               ).restrictLimitTo(
                 cfg.maxItemPageSize
               )
+              limitCapped = userQuery.limit.exists(_ > cfg.maxItemPageSize)
               itemQuery = ItemQueryString(userQuery.query)
               settings = OSimpleSearch.Settings(
                 batch,
@@ -62,7 +63,12 @@ object ShareSearchRoutes {
               account = share.account
               fixQuery = Query.Fix(account, Some(share.query.expr), None)
               _ <- logger.debug(s"Searching in share ${share.id.id}: ${userQuery.query}")
-              resp <- ItemRoutes.searchItems(backend, dsl)(settings, fixQuery, itemQuery)
+              resp <- ItemRoutes.searchItems(backend, dsl)(
+                settings,
+                fixQuery,
+                itemQuery,
+                limitCapped
+              )
             } yield resp
           }
           .getOrElseF(NotFound())

--- a/modules/webapp/src/main/elm/Data/Items.elm
+++ b/modules/webapp/src/main/elm/Data/Items.elm
@@ -64,10 +64,10 @@ concat l0 l1 =
                     suff =
                         List.drop 1 l1.groups
                 in
-                ItemLightList (prev ++ (ng :: suff))
+                ItemLightList (prev ++ (ng :: suff)) 0 0 False
 
             else
-                ItemLightList (l0.groups ++ l1.groups)
+                ItemLightList (l0.groups ++ l1.groups) 0 0 False
 
 
 first : ItemLightList -> Maybe ItemLight
@@ -121,7 +121,7 @@ replaceIn origin replacements =
                 |> ItemLightGroup g.name
     in
     List.map replaceGroup origin.groups
-        |> ItemLightList
+        |> (\els -> ItemLightList els origin.limit origin.offset origin.limitCapped)
 
 
 


### PR DESCRIPTION
The server defines a `limit` value and search requests are capped to
this limit if their requested value exceeds it. If this happens it is
now returned with the search response (clients can print a warning).

Closes: #1358