### PR TITLE
restserver docker image: set jdk17 for all platforms

### DIFF
--- a/docker/dockerfiles/restserver.dockerfile
+++ b/docker/dockerfiles/restserver.dockerfile
@@ -1,21 +1,19 @@
-FROM alpine:3.14
+FROM alpine:3.16
 
 ARG version=
 ARG restserver_url=
 ARG TARGETPLATFORM
 
-RUN JDKPKG="openjdk11-jre"; \
-    if [[ $TARGETPLATFORM = linux/arm* ]]; then JDKPKG="openjdk8-jre"; fi; \
-    apk update && \
-    apk add --no-cache $JDKPKG bash tzdata && \
+RUN apk update && \
+    apk add --no-cache openjdk17-jre bash tzdata curl && \
     apk add 'zlib=1.2.12-r3'
 
 WORKDIR /opt
-RUN wget ${restserver_url:-https://github.com/eikek/docspell/releases/download/v$version/docspell-restserver-$version.zip} && \
-  unzip docspell-restserver-*.zip && \
-  rm docspell-restserver-*.zip && \
-  ln -snf docspell-restserver-* docspell-restserver && \
-  rm docspell-restserver/conf/docspell-server.conf
+RUN curl -L -O ${restserver_url:-https://github.com/eikek/docspell/releases/download/v$version/docspell-restserver-$version.zip} && \
+    unzip docspell-restserver-*.zip && \
+    rm docspell-restserver-*.zip && \
+    ln -snf docspell-restserver-* docspell-restserver && \
+    rm docspell-restserver/conf/docspell-server.conf
 
 ENTRYPOINT ["/opt/docspell-restserver/bin/docspell-restserver", "-J-XX:+UseG1GC"]
 EXPOSE 7880


### PR DESCRIPTION
This is an attempt to fix #1712. First tests seem to be ok, no crashes anymore. However I will keep using the image for the next few hours, upload some new data and see whether I encounter any issues. Will report back. In the meantime: I made some changes to the image:

- set openjdk17 for all platforms because it is a LT supported jre/jdk version and works with Scala 3.2.18
- use `curl` for downloading the app `.zip` because I had troubles building the image, `wget` failed during build process. I guess that it doesn't follow redirects because I first had the same issue with `curl` but with the `-L` flag it worked
- update alpine version, however I think we could even use the `3` tag so that we always get the newest minor version, what do you think?

If you like I can also adjust the `joex` image description with the same changes.

... and last but not least, thank you for that awesome webapp 🥳 