### PR TITLE
Allow to authenticate with the same account from different sources

### DIFF
--- a/modules/backend/src/main/scala/docspell/backend/PasswordCrypt.scala
+++ b/modules/backend/src/main/scala/docspell/backend/PasswordCrypt.scala
@@ -11,10 +11,13 @@ import docspell.common.Password
 import org.mindrot.jbcrypt.BCrypt
 
 object PasswordCrypt {
+  // BCrypt requires non-empty strings
 
   def crypt(pass: Password): Password =
-    Password(BCrypt.hashpw(pass.pass, BCrypt.gensalt()))
+    if (pass.isEmpty) sys.error("Empty password given to hash")
+    else Password(BCrypt.hashpw(pass.pass, BCrypt.gensalt()))
 
   def check(plain: Password, hashed: Password): Boolean =
-    BCrypt.checkpw(plain.pass, hashed.pass)
+    if (plain.isEmpty || hashed.isEmpty) false
+    else BCrypt.checkpw(plain.pass, hashed.pass)
 }

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -95,6 +95,17 @@ docspell.server {
       # How long the remember me cookie/token is valid.
       valid = "30 days"
     }
+
+    # One of: fail, convert
+    #
+    # Accounts can be local or defined at a remote provider and
+    # integrated via OIDC. If the same account is defined in both
+    # sources, docspell by default fails if a user mixes logins (e.g.
+    # when registering a user locally and then logging in with the
+    # same user via OIDC). When set to `convert` docspell treats it as
+    # being the same and simply updates the account to reflect the new
+    # account source.
+    on-account-source-conflict = "fail"
   }
 
   # Settings for "download as zip"

--- a/modules/restserver/src/main/scala/docspell/restserver/ConfigFile.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/ConfigFile.scala
@@ -11,6 +11,7 @@ import java.security.SecureRandom
 import cats.Monoid
 import cats.effect.Async
 
+import docspell.backend.auth.Login
 import docspell.backend.signup.{Config => SignupConfig}
 import docspell.config.Implicits._
 import docspell.config.{ConfigFactory, FtsType, Validation}
@@ -50,6 +51,10 @@ object ConfigFile {
 
     implicit val openIdExtractorReader: ConfigReader[OpenId.UserInfo.Extractor] =
       ConfigReader[String].emap(reason(OpenId.UserInfo.Extractor.fromString))
+
+    implicit val onAccountSourceConflictReader
+        : ConfigReader[Login.OnAccountSourceConflict] =
+      ConfigReader[String].emap(reason(Login.OnAccountSourceConflict.fromString))
   }
 
   def generateSecretIfEmpty: Validation[Config] =

--- a/modules/restserver/src/main/scala/docspell/restserver/RestAppImpl.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/RestAppImpl.scala
@@ -81,7 +81,7 @@ final class RestAppImpl[F[_]: Async](
     Router(
       "fts" -> FullTextIndexRoutes.admin(config, backend),
       "user/otp" -> TotpRoutes.admin(backend),
-      "user" -> UserRoutes.admin(backend),
+      "user" -> UserRoutes.admin(backend, config.auth),
       "info" -> InfoRoutes.admin(config),
       "attachments" -> AttachmentRoutes.admin(backend),
       "files" -> FileRepositoryRoutes.admin(backend)
@@ -129,7 +129,7 @@ final class RestAppImpl[F[_]: Async](
       "person" -> PersonRoutes(backend, token),
       "source" -> SourceRoutes(backend, token),
       "user/otp" -> TotpRoutes(backend, config, token),
-      "user" -> UserRoutes(backend, token),
+      "user" -> UserRoutes(backend, config.auth, token),
       "collective" -> CollectiveRoutes(backend, token),
       "queue" -> JobQueueRoutes(backend, token),
       "item" -> ItemRoutes(config, backend, token),

--- a/modules/restserver/src/main/scala/docspell/restserver/auth/OpenId.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/auth/OpenId.scala
@@ -105,6 +105,7 @@ object OpenId {
     import dsl._
 
     for {
+      _ <- logger.debug(s"Setting up external account: ${accountId.asString}")
       setup <- backend.signup.setupExternal(ExternalAccount(accountId))
       res <- setup match {
         case SignupResult.Failure(ex) =>
@@ -143,6 +144,7 @@ object OpenId {
     import dsl._
 
     for {
+      _ <- logger.debug(s"Login and verify external account: ${accountId.asString}")
       login <- backend.login.loginExternal(config.auth)(accountId)
       resp <- login match {
         case Login.Result.Ok(session, _) =>
@@ -158,7 +160,9 @@ object OpenId {
             .map(_.addCookie(CookieData(session).asCookie(baseUrl)))
 
         case failed =>
-          logger.error(s"External login failed: $failed") *>
+          logger.error(
+            s"External login failed: $failed. ${failed.toEither.left.getOrElse("")}"
+          ) *>
             SeeOther(location)
       }
     } yield resp

--- a/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
@@ -699,8 +699,11 @@ trait Conversions {
       case PassChangeResult.PasswordMismatch =>
         BasicResult(false, "The current password is incorrect.")
       case PassChangeResult.UserNotFound => BasicResult(false, "User not found.")
-      case PassChangeResult.UserNotLocal =>
-        BasicResult(false, "User is not local, passwords are managed externally.")
+      case PassChangeResult.InvalidSource(source) =>
+        BasicResult(
+          false,
+          s"User has invalid soure: $source. Passwords are managed elsewhere."
+        )
     }
 
   def basicResult(e: Either[Throwable, _], successMsg: String): BasicResult =

--- a/modules/store/src/main/scala/docspell/store/records/RUser.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RUser.scala
@@ -204,9 +204,18 @@ object RUser {
     val t = Table(None)
     DML.update(
       t,
-      t.cid === collId && t.uid === userId && t.source === AccountSource.Local,
+      t.cid === collId && t.uid === userId,
       DML.set(t.password.setTo(hashedPass))
     )
+  }
+
+  def updateSource(
+      userId: Ident,
+      collId: CollectiveId,
+      source: AccountSource
+  ): ConnectionIO[Int] = {
+    val t = Table(None)
+    DML.update(t, t.uid === userId && t.cid === collId, DML.set(t.source.setTo(source)))
   }
 
   def delete(user: Ident, coll: CollectiveId): ConnectionIO[Int] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
 
   val scribe = Seq(
     "com.outr" %% "scribe" % ScribeVersion,
-    "com.outr" %% "scribe-slf4j" % ScribeVersion
+    "com.outr" %% "scribe-slf4j2" % ScribeVersion
   )
 
   val sourcecode = Seq(

--- a/website/site/content/docs/configure/authentication.md
+++ b/website/site/content/docs/configure/authentication.md
@@ -145,3 +145,36 @@ provider, skipping the login page for Docspell.
 
 For logging out, you can specify a `logout-url` for the provider which
 is used to redirect the browser after logging out from Docspell.
+
+## Mixing OIDC and local accounts
+
+Local accounts and those created from an openid provider can live next
+to each other. There is only a caveat for accounts with same login
+name that may occur from local and openid providers. By default,
+docspell treats OIDC and local accounts always as different when
+logging in.
+
+That means when a local user exists and the same account is trying to
+login via an openid provider, docspell fails the authentication
+attempt by default. It could be that these accounts belong to
+different persons in reality.
+
+The other way around is the same: signing up an account that exists
+due to an OIDC login doesn't work, because the collective already
+exists. And obviously, logging in without a password doesn't work
+either :). Even if a password would exists for an account created by
+an OIDC flow, logging in with it doesn't work. It would allow to
+bypass the openid provider (which may not be desired)
+
+This behavior can be changed by setting:
+
+```
+on-account-source-conflict = convert
+```
+
+in the config file (or environment variable). With this setting,
+accounts with same name are treated identical, independet where they
+came from. So you can login either locally **or** via the configured
+openid provider. Note that this also allows users to set a local
+password by themselves (which may not adhere to the password rules you
+can potentially define at an openid provider).


### PR DESCRIPTION
A new config allows to treat an account same independent where it was created (openid or local).