### PR TITLE
Remove explicit install of zlib

### DIFF
--- a/docker/dockerfiles/joex.dockerfile
+++ b/docker/dockerfiles/joex.dockerfile
@@ -53,7 +53,6 @@ RUN apk update && \
     qpdf-dev \
     openssl-dev \
     ocrmypdf \
-  && apk add 'zlib=1.2.12-r3' \
   && pip3 install --upgrade pip \
   && pip3 install ocrmypdf \
   && curl -Ls $UNO_URL -o /usr/local/bin/unoconv \

--- a/docker/dockerfiles/restserver.dockerfile
+++ b/docker/dockerfiles/restserver.dockerfile
@@ -5,8 +5,7 @@ ARG restserver_url=
 ARG TARGETPLATFORM
 
 RUN apk update && \
-    apk add --no-cache openjdk17-jre bash tzdata curl && \
-    apk add 'zlib=1.2.12-r3'
+    apk add --no-cache openjdk17-jre bash tzdata curl
 
 WORKDIR /opt
 RUN curl -L -O ${restserver_url:-https://github.com/eikek/docspell/releases/download/v$version/docspell-restserver-$version.zip} && \


### PR DESCRIPTION
The explicit install was added earlier due to a broken zlib package (see issue #1517). This has now been fixed for a while in alpine and can be removed.