### PR TITLE
nix: add extraConfig option

### DIFF
--- a/nix/checks/configuration-test.nix
+++ b/nix/checks/configuration-test.nix
@@ -58,6 +58,16 @@ in
       }
     ];
     inherit full-text-search;
+    extraConfig = {
+      files = {
+        default-store = "database";
+        stores = {
+          minio = {
+            enabled = true;
+          };
+        };
+      };
+    };
   };
 
   environment.systemPackages =


### PR DESCRIPTION
This commit adds a new option for joex and server modules - extraConfig. Its main use-case is to specify options that are present in docspell but not (perhaps, yet) defined in the modules.