### PR TITLE
nix: replace wkhtmltopdf with weasyprint

### DIFF
--- a/nix/checks/configuration-test.nix
+++ b/nix/checks/configuration-test.nix
@@ -15,7 +15,7 @@ in
   i18n = {
     defaultLocale = "en_US.UTF-8";
   };
-  console.keyMap = "de";
+  console.keyMap = "us";
 
   users.users.root = {
     password = "root";
@@ -88,6 +88,9 @@ in
     firewall.allowedTCPPorts = [ 7880 ];
   };
 
-  system.stateVersion = "22.05";
+  system.stateVersion = "22.11";
+
+  # This slows down the build of a vm
+  documentation.enable = false;
 
 }

--- a/nix/checks/solr.nix
+++ b/nix/checks/solr.nix
@@ -6,8 +6,6 @@
   nixpkgs.config = {
     permittedInsecurePackages = [
       "solr-8.6.3"
-      # NOTE: Qtwebkit is a dep for wkhtmltopdf, this line is needed until #201765 is fixed in nixpkgs
-      "qtwebkit-5.212.0-alpha4"
     ];
   };
 

--- a/nix/dev-vm/default.nix
+++ b/nix/dev-vm/default.nix
@@ -1,0 +1,28 @@
+# NOTE: modulesPath and imports are taken from nixpkgs#59219
+{ modulesPath, pkgs, lib, ... }: {
+  imports = [ (modulesPath + "/virtualisation/qemu-vm.nix") ];
+  services.openssh = {
+    enable = true;
+    permitRootLogin = "yes";
+  };
+
+  services.docspell-restserver = {
+    openid = lib.mkForce [ ];
+    backend = lib.mkForce {
+      signup = {
+        mode = "open";
+      };
+    };
+  };
+
+  # Otherwise oomkiller kills docspell
+  virtualisation.memorySize = 2048;
+
+  virtualisation.forwardPorts = [
+    # SSH
+    { from = "host"; host.port = 64022; guest.port = 22; }
+    # Docspell
+    { from = "host"; host.port = 64080; guest.port = 7880; }
+  ];
+
+}

--- a/nix/dev-vm/default.nix
+++ b/nix/dev-vm/default.nix
@@ -16,7 +16,7 @@
   };
 
   # Otherwise oomkiller kills docspell
-  virtualisation.memorySize = 2048;
+  virtualisation.memorySize = 4096;
 
   virtualisation.forwardPorts = [
     # SSH

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669735802,
-        "narHash": "sha256-qtG/o/i5ZWZLmXw108N2aPiVsxOcidpHJYNkT45ry9Q=",
+        "lastModified": 1673704454,
+        "narHash": "sha256-5Wdj1MgdOgn3+dMFIBtg+IAYZApjF8JzwLWDPieg0C4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "731cc710aeebecbf45a258e977e8b68350549522",
+        "rev": "a83ed85c14fcf242653df6f4b0974b7e1c73c6c6",
         "type": "github"
       },
       "original": {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -115,5 +115,20 @@
         joex = ((import ./modules/joex.nix) self.overlays.default);
       };
 
+      nixosConfigurations =
+        let
+          lib = nixpkgs.lib;
+        in
+        {
+          dev-vm = lib.makeOverridable nixpkgs.lib.nixosSystem {
+            system = "x86_64-linux";
+            modules = [
+              self.nixosModules.default
+              ./checks
+              # nixos-shell specific module. Should be kept outside nix flake checks
+              ./dev-vm
+            ];
+          };
+        };
     };
 }

--- a/nix/modules/joex.nix
+++ b/nix/modules/joex.nix
@@ -178,8 +178,24 @@ let
 
       wkhtmlpdf = {
         command = {
-          program = "${pkgs.wkhtmltopdf}/bin/wkhtmltopdf";
-          args = [ "-s" "A4" "--encoding" "UTF-8" "-" "{{outfile}}" ];
+          program = "";
+          args = [ "--encoding" "UTF-8" "-" "{{outfile}}" ];
+          timeout = "2 minutes";
+        };
+        working-dir = "/tmp/docspell-convert";
+      };
+
+      weasyprint = {
+        command = {
+          program = "${pkgs.python310Packages.weasyprint}/bin/weasyprint";
+          args = [
+            "--optimize-size"
+            "all"
+            "--encoding"
+            "{{encoding}}"
+            "-"
+            "{{outfile}}"
+          ];
           timeout = "2 minutes";
         };
         working-dir = "/tmp/docspell-convert";
@@ -1207,6 +1223,11 @@ in
                 converted to a PDF file.
               '';
             };
+            html-converter = mkOption {
+              type = types.enum [ "wkhtmlpdf" "weasyprint" ];
+              default = "weasyprint";
+              description = "Which tool to use for converting html to pdfs";
+            };
             wkhtmlpdf = mkOption {
               type = types.submodule ({
                 options = {
@@ -1244,6 +1265,45 @@ in
               description = ''
                 To convert HTML files into PDF files, the external tool
                 wkhtmltopdf is used.
+              '';
+            };
+            weasyprint = mkOption {
+              type = types.submodule ({
+                options = {
+                  working-dir = mkOption {
+                    type = types.str;
+                    default = defaults.convert.weasyprint.working-dir;
+                    description = "Directory where the conversion processes can put their temp files";
+                  };
+                  command = mkOption {
+                    type = types.submodule ({
+                      options = {
+                        program = mkOption {
+                          type = types.str;
+                          default = defaults.convert.weasyprint.command.program;
+                          description = "The path to the executable.";
+                        };
+                        args = mkOption {
+                          type = types.listOf types.str;
+                          default = defaults.convert.weasyprint.command.args;
+                          description = "The arguments to the program";
+                        };
+                        timeout = mkOption {
+                          type = types.str;
+                          default = defaults.convert.weasyprint.command.timeout;
+                          description = "The timeout when executing the command";
+                        };
+                      };
+                    });
+                    default = defaults.convert.weasyprint.command;
+                    description = "The system command";
+                  };
+                };
+              });
+              default = defaults.convert.weasyprint;
+              description = ''
+                To convert HTML files into PDF files, the external tool
+                weasyprint is used.
               '';
             };
             tesseract = mkOption {

--- a/website/site/content/docs/dev/development.md
+++ b/website/site/content/docs/dev/development.md
@@ -126,43 +126,35 @@ warnings should also be fixed.
 
 # Nix Expressions
 
-The directory `/nix` contains nix expressions to install docspell via
+The directory `/nix` contains Nix Flake to install docspell via
 the nix package manager and to integrate it into NixOS.
 
-## Testing NixOS Modules
+Flake implements `checks` output which can be run with `nix flake check`
+and it defines a development VM which can be used to interactively work
+with docspell.
 
-The modules can be build by building the `configuration-test.nix` file
-together with some nixpkgs version. For example:
+To run the VM, issue:
 
-``` bash
-nixos-rebuild build-vm -I nixos-config=./configuration-test.nix \
-  -I nixpkgs=https://github.com/NixOS/nixpkgs-channels/archive/nixos-19.09.tar.gz
+```bash
+cd $PROJECT_ROOT/nix
+nix run '.#nixosConfigurations.dev-vm.config.system.build.vm
 ```
 
-This will build all modules imported in `configuration-test.nix` and
-create a virtual machine containing the system. After that completes,
-the system configuration can be found behind the `./result/system`
-symlink. So it is possible to look at the generated systemd config for
-example:
+To open docspell, wait for docspell-restserver service to report that
+http listener is up and connect to `localhost:64080`.
 
-``` bash
-cat result/system/etc/systemd/system/docspell-joex.service
+To ssh into the machine, run:
+
+```bash
+ssh -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -p 64022 root@localhost
 ```
 
-And with some more commands (there probably is an easier way…) the
-config file can be checked:
+Once connected to the machine, you can see the docspell config file via
 
-``` bash
-cat result/system/etc/systemd/system/docspell-joex.service | grep ExecStart | cut -d'=' -f2 | xargs cat | tail -n1 | awk '{print $NF}'| sed 's/.$//' | xargs cat | jq
-```
-
-To see the module in action, the vm can be started (the first line
-sets more memory for the vm):
-
-``` bash
-export QEMU_OPTS="-m 2048"
-export QEMU_NET_OPTS "hostfwd=tcp::7880-:7880"
-./result/bin/run-docspelltest-vm
+```bash
+systemd-show docspell-joex.service | grep ExecStart | cut -d'=' -f2 | xargs cat | tail -n1 | awk '{print $NF}'| sed 's/.$//' | xargs cat | jq
 ```
 
 # Release


### PR DESCRIPTION
Wkhtmltopdf is deemed insecure and requires a full build of qtwebengine. I am working on replacing wkhtmltopdf with weasyprint in Nix module definitions.

See #1873 for more background