### PR TITLE
Fix bad defined dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -662,7 +662,7 @@ val ftspsql = project
         Dependencies.postgres ++
         Dependencies.flyway
   )
-  .dependsOn(common, ftsclient, store % "compile->test;test->test")
+  .dependsOn(common, ftsclient, store % "compile->compile;test->test")
 
 val restapi = project
   .in(file("modules/restapi"))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -198,6 +198,7 @@ object Dependencies {
       ExclusionRule("com.sun.xml.bind", "jaxb-core"),
       ExclusionRule("javax.xml.bind", "jaxb-api"),
       ExclusionRule("javax.activation"),
+      ExclusionRule("junit", "junit"),
       ExclusionRule("de.jollyday", "jollyday"),
       ExclusionRule("com.apple", "AppleJavaExtensions"),
       ExclusionRule("org.glassfish", "javax.json")

--- a/project/TestSettings.scala
+++ b/project/TestSettings.scala
@@ -10,13 +10,11 @@ object TestSettingsPlugin extends AutoPlugin {
       ds.fold(d0)(_ ++ _).map(_ % Test)
 
     implicit class ProjectTestSettingsSyntax(project: Project) {
-      def withTestSettings =
+      def withTestSettings: Project =
         project.settings(testSettings)
 
-      def withTestSettingsDependsOn(p: Project, ps: Project*) =
-        (p :: ps.toList).foldLeft(project) { (cur, dep) =>
-          cur.dependsOn(dep % "test->test,compile")
-        }
+      def withTestSettingsDependsOn(p: Project, ps: Project*): Project =
+        withTestSettings.dependsOn((p +: ps).map(_ % "test->test"): _*)
     }
 
     implicit class CrossprojectTestSettingsSyntax(project: CrossProject) {
@@ -29,7 +27,7 @@ object TestSettingsPlugin extends AutoPlugin {
   import autoImport._
 
   val testSettings = Seq(
-    libraryDependencies ++= inTest(Dependencies.munit, Dependencies.scribe),
+    libraryDependencies ++= (Dependencies.munit ++ Dependencies.scribe).map(_ % Test),
     testFrameworks += TestFrameworks.MUnit
   )
 


### PR DESCRIPTION
Must not be `compile->test` as this pulls in test dependencies of the other project. Also improves on `withTestSettingsDependsOn` and removes junit dependency from stanfordnlp-core.

Issue: #1856