### PR TITLE
Improve error reporting when a file cannot be stored

### DIFF
--- a/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
@@ -689,6 +689,11 @@ trait Conversions {
       case UploadResult.NoItem   => BasicResult(false, "The item could not be found.")
       case UploadResult.NoCollective =>
         BasicResult(false, "The collective could not be found.")
+      case UploadResult.StoreFailure(_) =>
+        BasicResult(
+          false,
+          "There were errors storing a file! See the server logs for details."
+        )
     }
 
   def basicResult(cr: PassChangeResult): BasicResult =


### PR DESCRIPTION
Fixes logging the error (the effect was not evaluated before) and also distinguishes this case from having no files in the request.

Closes: #1976