### PR TITLE
add khmer lang

### DIFF
--- a/docker/docker-compose/docker-compose.yml
+++ b/docker/docker-compose/docker-compose.yml
@@ -126,8 +126,9 @@ services:
     volumes:
       - docspell-solr_data:/var/solr
     command:
-      - solr-precreate
-      - docspell
+      - bash
+      - -c
+      - 'precreate-core docspell; exec solr -f -Dsolr.modules=analysis-extras'
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8983/solr/docspell/admin/ping"]
       interval: 1m

--- a/docker/dockerfiles/joex.dockerfile
+++ b/docker/dockerfiles/joex.dockerfile
@@ -40,6 +40,7 @@ RUN apk update && \
     ttf-dejavu \
     ttf-freefont \
     ttf-liberation \
+    font-noto-khmer \
     libxml2-dev \
     libxslt-dev \
     pngquant \
@@ -63,6 +64,7 @@ RUN apk update && \
 RUN apk add --no-cache py3-setuptools && ocrmypdf --version
 
 WORKDIR /opt
+
 RUN wget ${joex_url:-https://github.com/eikek/docspell/releases/download/v$version/docspell-joex-$version.zip} && \
   unzip docspell-joex-*.zip && \
   rm docspell-joex-*.zip && \

--- a/docker/dockerfiles/joex.dockerfile
+++ b/docker/dockerfiles/joex.dockerfile
@@ -33,6 +33,7 @@ RUN apk update && \
     tesseract-ocr-data-pol \
     tesseract-ocr-data-est \
     tesseract-ocr-data-ukr \
+    tesseract-ocr-data-khm \
     unpaper \
     weasyprint \
     libreoffice \

--- a/docker/dockerfiles/joex.dockerfile
+++ b/docker/dockerfiles/joex.dockerfile
@@ -33,7 +33,6 @@ RUN apk update && \
     tesseract-ocr-data-pol \
     tesseract-ocr-data-est \
     tesseract-ocr-data-ukr \
-    tesseract-ocr-data-khm \
     unpaper \
     weasyprint \
     libreoffice \
@@ -69,6 +68,12 @@ RUN wget ${joex_url:-https://github.com/eikek/docspell/releases/download/v$versi
   rm docspell-joex-*.zip && \
   ln -snf docspell-joex-* docspell-joex && \
   rm docspell-joex/conf/docspell-joex.conf
+
+# temporary download traineddata directly for khmer lang
+# before tesseract-ocr-data-khm being added to the registry
+RUN \
+  wget https://github.com/tesseract-ocr/tessdata/raw/main/khm.traineddata && \
+  mv khm.traineddata /usr/share/tessdata
 
 # Using these data files for japanese, because they work better. See #973
 RUN \

--- a/modules/analysis/src/main/scala/docspell/analysis/date/DateFind.scala
+++ b/modules/analysis/src/main/scala/docspell/analysis/date/DateFind.scala
@@ -129,6 +129,7 @@ object DateFind {
         case Language.Lithuanian => ymd
         case Language.Polish     => dmy
         case Language.Estonian   => dmy
+        case Language.Khmer      => dmy
         case Language.Ukrainian  => dmy.or(ymd)
       }
       p.read(parts) match {

--- a/modules/analysis/src/main/scala/docspell/analysis/date/MonthName.scala
+++ b/modules/analysis/src/main/scala/docspell/analysis/date/MonthName.scala
@@ -64,6 +64,8 @@ object MonthName {
         estonian
       case Language.Ukrainian =>
         ukrainian
+      case Language.Khmer =>
+        khmer
     }
 
   private val numbers = List(
@@ -79,6 +81,21 @@ object MonthName {
     List("10"),
     List("11"),
     List("12")
+  )
+
+  private val khmer = List(
+    List("០១", "មករា"),
+    List("០២", "កុម្ភៈ"),
+    List("០៣", "មិនា"),
+    List("០៤", "មេសា"),
+    List("០៥", "ឧសភា"),
+    List("០៦", "មិថុនា"),
+    List("០៧", "កក្កដា"),
+    List("០៨", "សីហា"),
+    List("០៩", "កញ្ញា"),
+    List("១០", "តុលា"),
+    List("១១", "វិច្ឆិកា"),
+    List("១២", "ធ្នូ")
   )
 
   private val english = List(

--- a/modules/common/src/main/scala/docspell/common/Language.scala
+++ b/modules/common/src/main/scala/docspell/common/Language.scala
@@ -36,7 +36,7 @@ object Language {
   case object German extends NLPLanguage {
     val iso2 = "de"
     val iso3 = "deu"
-  } 
+  }
 
   case object English extends NLPLanguage {
     val iso2 = "en"

--- a/modules/common/src/main/scala/docspell/common/Language.scala
+++ b/modules/common/src/main/scala/docspell/common/Language.scala
@@ -36,7 +36,7 @@ object Language {
   case object German extends NLPLanguage {
     val iso2 = "de"
     val iso3 = "deu"
-  }
+  } 
 
   case object English extends NLPLanguage {
     val iso2 = "en"
@@ -71,6 +71,11 @@ object Language {
   case object Czech extends Language {
     val iso2 = "cs"
     val iso3 = "ces"
+  }
+
+  case object Khmer extends Language {
+    val iso2 = "kh"
+    val iso3 = "khm"
   }
 
   case object Danish extends Language {
@@ -166,7 +171,8 @@ object Language {
       Lithuanian,
       Polish,
       Estonian,
-      Ukrainian
+      Ukrainian,
+      Khmer
     )
 
   def fromString(str: String): Either[String, Language] = {

--- a/modules/fts-psql/src/main/scala/docspell/ftspsql/FtsRepository.scala
+++ b/modules/fts-psql/src/main/scala/docspell/ftspsql/FtsRepository.scala
@@ -206,5 +206,6 @@ object FtsRepository extends DoobieMeta {
       case Language.Polish     => "simple"
       case Language.Estonian   => "simple"
       case Language.Ukrainian  => "simple"
+      case Language.Khmer      => "simple"
     }
 }

--- a/modules/fts-solr/src/main/scala/docspell/ftssolr/Field.scala
+++ b/modules/fts-solr/src/main/scala/docspell/ftssolr/Field.scala
@@ -30,6 +30,7 @@ object Field {
   val content_de = contentField(Language.German)
   val content_en = contentField(Language.English)
   val content_fr = contentField(Language.French)
+  val content_kh = contentField(Language.Khmer)
   val itemName = Field("itemName")
   val itemNotes = Field("itemNotes")
   val folderId = Field("folder")

--- a/modules/fts-solr/src/main/scala/docspell/ftssolr/SolrSetup.scala
+++ b/modules/fts-solr/src/main/scala/docspell/ftssolr/SolrSetup.scala
@@ -172,7 +172,18 @@ object SolrSetup {
             "Add Ukrainian",
             addContentField(Language.Ukrainian)
           ),
-          SolrMigration.reIndexAll(31, "Re-Index after adding Estonian and Ukrainian")
+          SolrMigration.reIndexAll(31, "Re-Index after adding Estonian and Ukrainian"),
+          SolrMigration[F](
+            32,
+            "Add new field type for khmer content",
+            addFieldType(AddFieldType.textKhm)
+          ),
+          SolrMigration[F](
+            33,
+            "Add Khmer",
+            addContentField(Language.Khmer)
+          ),
+          SolrMigration.reIndexAll(34, "Re-Index after adding Khmer")
         )
 
       def addFolderField: F[Unit] =
@@ -343,6 +354,16 @@ object SolrSetup {
         Tokenizer("solr.StandardTokenizerFactory", Map.empty),
         List(
           Filter("solr.LowerCaseFilterFactory", Map.empty)
+        )
+      )
+    )
+
+    val textKhm = AddFieldType(
+      "text_kh",
+      "solr.TextField",
+      Analyzer(
+        Tokenizer("solr.ICUTokenizerFactory", Map.empty),
+        List(
         )
       )
     )

--- a/modules/webapp/src/main/elm/Data/Language.elm
+++ b/modules/webapp/src/main/elm/Data/Language.elm
@@ -36,6 +36,7 @@ type Language
     | Polish
     | Estonian
     | Ukrainian
+    | Khmer
 
 
 fromString : String -> Maybe Language
@@ -105,6 +106,9 @@ fromString str =
 
     else if str == "ukr" || str == "uk" || str == "ukrainian" then
         Just Ukrainian
+
+    else if str == "khm" || str == "kh" || str == "khmer" then
+        Just Khmer
 
     else
         Nothing
@@ -179,6 +183,9 @@ toIso3 lang =
         Ukrainian ->
             "ukr"
 
+        Khmer ->
+            "khm"
+
 
 all : List Language
 all =
@@ -204,4 +211,5 @@ all =
     , Polish
     , Estonian
     , Ukrainian
+    , Khmer
     ]

--- a/modules/webapp/src/main/elm/Messages/Data/Language.elm
+++ b/modules/webapp/src/main/elm/Messages/Data/Language.elm
@@ -83,6 +83,9 @@ gb lang =
         Ukrainian ->
             "Ukrainian"
 
+        Khmer ->
+            "Khmer"
+
 
 de : Language -> String
 de lang =
@@ -153,6 +156,9 @@ de lang =
         Ukrainian ->
             "Ukrainisch"
 
+        Khmer ->
+            "Khmer"
+
 
 fr : Language -> String
 fr lang =
@@ -222,3 +228,6 @@ fr lang =
 
         Ukrainian ->
             "Ukrainien"
+
+        Khmer ->
+            "Khmer"

--- a/website/site/content/docs/install/prereq.md
+++ b/website/site/content/docs/install/prereq.md
@@ -79,6 +79,11 @@ documentation](https://solr.apache.org/guide/8_4/installing-solr.html).
 That will provide you with the connection url (the last part is the
 core name).
 
+Then start solr with `-Dsolr.modules=analysis-extras`
+to enable some additional analyzer like `icu` for `Khmer` language etc
+as described [here](https://solr.apache.org/guide/solr/latest/indexing-guide/language-analysis.html#hebrew-lao-myanmar-khmer),
+which we used for tokenization and segmentation for `Khmer` language in docspell.
+
 When using the provided `docker-compose.yml` setup, SOLR is already setup.
 
 SOLR must be reachable from all joex and all rest server components.


### PR DESCRIPTION
this pr contains

- update to `solr` in `docker-compose.yml` to enable `analysis-extras` module for `icu` tokenizer
- add `Khmer` lang according to the [guide](https://docspell.org/docs/dev/add-language/) but skip the adding test step
- update docs about `solr` in https://docspell.org/docs/install/prereq/ that also need `extra-analysis` module in order for text analysis to be working for `khmer` language
- update `joex.dockerfile` to add khmer font and tesseract khmer model