### PR TITLE
Add logic to set due date from addons, based on #2362

### DIFF
--- a/modules/backend/src/main/scala/docspell/backend/BackendCommands.scala
+++ b/modules/backend/src/main/scala/docspell/backend/BackendCommands.scala
@@ -127,6 +127,12 @@ private[backend] class BackendCommands[F[_]: Sync](
           itemOps
             .setItemDate(Nel.of(item), date.some, collective)
             .void
+
+      case ItemAction.SetDueDate(duedate) =>
+        logger.debug(s"Set due date $duedate on item ${item.id} for $collective") *>
+          itemOps
+            .setItemDueDate(Nel.of(item), duedate, collective)
+            .void
     }
 
   def runAttachAction(

--- a/modules/common/src/main/scala/docspell/common/bc/ItemAction.scala
+++ b/modules/common/src/main/scala/docspell/common/bc/ItemAction.scala
@@ -105,4 +105,10 @@ object ItemAction {
     implicit val jsonDecoder: Decoder[SetDate] = deriveDecoder
     implicit val jsonEncoder: Encoder[SetDate] = deriveEncoder
   }
+
+  case class SetDueDate(duedate: Option[Timestamp]) extends ItemAction
+  object SetDueDate {
+    implicit val jsonDecoder: Decoder[SetDueDate] = deriveDecoder
+    implicit val jsonEncoder: Encoder[SetDueDate] = deriveEncoder
+  }
 }

--- a/website/src/main/scala/docspell/website/AddonOutputExample.scala
+++ b/website/src/main/scala/docspell/website/AddonOutputExample.scala
@@ -21,6 +21,7 @@ object AddonOutputExample extends Helper {
           ItemAction.ReplaceTags(Set("tagX", "tagY")),
           ItemAction.RemoveTags(Set("tag0", "tag9")),
           ItemAction.RemoveTagsCategory(Set("doc-type")),
+          ItemAction.SetDueDate(Some(Timestamp.ofMillis(1707908400000L))),
           ItemAction.SetFolder("folder-name".some),
           ItemAction.SetCorrOrg(id("OaIy-org-ID").some),
           ItemAction.SetCorrPerson(id("OaIy-person-ID").some),


### PR DESCRIPTION
This allows addons to set or remove the due date, by outputting the following structure:

```
{ "duedate": 1707908400000, "action": "set-due-date" }
```

Alternatively, you may set `duedate` to `null` to remove a due date.

Thanks to @eikek and @v6ak for the handholding!