### PR TITLE
tesseract english data is now a separate package

### DIFF
--- a/docker/dockerfiles/joex.dockerfile
+++ b/docker/dockerfiles/joex.dockerfile
@@ -18,6 +18,7 @@ RUN apk update && \
     tesseract-ocr-data-ita \
     tesseract-ocr-data-spa \
     tesseract-ocr-data-por \
+    tesseract-ocr-data-eng \
     tesseract-ocr-data-ces \
     tesseract-ocr-data-nld \
     tesseract-ocr-data-dan \


### PR DESCRIPTION
It looks like https://git.alpinelinux.org/aports/commit/community/tesseract-ocr?id=e1dc19b16f34ba3faeba489ea3412d3b3c67c12f introduced the english data language as a separate package.

I noticed this error when trying to run OCR on a file where I had selected english:

```
Error opening data file /usr/share/tessdata/eng.traineddata
Please make sure the TESSDATA_PREFIX environment variable is set to your "tessdata" directory.
Failed loading language 'eng'
```

In the docspell 0.40.0 joex image, the `tesseract-ocr-5.2.0-r1` includes `eng.traineddata` (english), `equ.traineddata` (math equation detection), and `osd.traineddata` (orientation and script detection). But the `tesseract-ocr-5.3.4-r0` package in docspell 0.41.0 joex doesn't include any of them.

I don't believe the osd/equ variants are used, so I didn't include them in the PR.