### PR TITLE
fix(webapp): downstream keep-alive events to backend preventing timeout

### DIFF
--- a/modules/webapp/src/main/webjar/docspell.js
+++ b/modules/webapp/src/main/webjar/docspell.js
@@ -152,6 +152,8 @@ function initWS() {
             var dataJSON = JSON.parse(event.data);
             if (dataJSON.tag !== "keep-alive") {
                 elmApp.ports.receiveWsMessage.send(dataJSON);
+            } else {
+                dsWebSocket.send(event.data);
             }
         }
     });


### PR DESCRIPTION
Updated http4s component fixed idleTimeout between backend and proxy / client that requires now to send keep-alive messages from client to backend to prevent a timeout after 60s.

This resolves #2497.