### PR TITLE
Add documentation for backup and restore process for PostgreSQL.

### DIFF
--- a/website/site/content/docs/dev/add-language.md
+++ b/website/site/content/docs/dev/add-language.md
@@ -11,7 +11,7 @@ Then there are other commits and issues to look at:
 - [Add Polish](https://github.com/eikek/docspell/issues/1345) and [PR](https://github.com/eikek/docspell/pull/1559/commits/5ec311c331f1f78cc483cce54d5ab0e08454fea8)
 - [Add Spanish language](https://github.com/eikek/docspell/commit/26dff18ae0d32ce2b32b4d11ce381ada0e99314f)
 - [Add Latvian language](https://github.com/eikek/docspell/issues/679) and [PR](https://github.com/eikek/docspell/pull/694/commits/9991ad5fcc43ccefe011a6cc4d01bdae4bcd4573)
-- [Add Japanese language](https://github.com/eikek/docspell/issues/948) and [PR](https://github.com/eikek/docspell/pull/961/commits/f994d4b2488e64668ee064676f8c6469d9ccc1be), had some corrections: [1](https://github.com/eikek/docspell/commit/c59d4f8a6d021ec4b01a92320c211248503f16a5), [Issue](https://github.com/eikek/docspell/issues/973)
+- [Add Japanese language](https://github.com/eikek/docspell/issues/948) and [PR](https://github.com/eikek/docspell/pull/961/commits/f994d4b2488e64668ee064676f8c6469d9ccc1be), had some corrections: [1](https://github.com/eikek/docspell/commit/c59d4f8a6d021ec4b01a92320c211248503f16a5), [Issue](https://github.com/eikek/docspell/issues/973), [2](https://github.com/eikek/docspell/pull/2505), [Issue](https://github.com/eikek/docspell/issues/2445)
 - [Add Hebrew language](https://github.com/eikek/docspell/pull/1027)
 
 Some older commits may be a bit out of date, but still show the

--- a/website/site/content/docs/install/download_run.md
+++ b/website/site/content/docs/install/download_run.md
@@ -102,16 +102,71 @@ your package manager or download and unpack the new zip files. You
 might want to have a look at the changelog, since it is sometimes
 necessary to modify the config file.
 
-## More
+## Backup & Restore
+
+There are several supported [databases](https://docspell.org/docs/configure/database/) but PostgreSQL is recommended for Docspell.
+
+First to prevent any currently queued data from being lost, it's good practice to 
+shutdown `docspell-joex` and `docspell-restserver` system services
+before taking a database backup of Docspell. In order to stop Docspell, 
+you need to perform these on the system that docspell is running on.
+```bash
+sudo systemctl stop docspell-joex
+sudo systemctl stop docspell-restserver
+```
+
+Next, you can become the `postgres` user or database admin user on 
+your PostgreSQL server/microservice and backup the database.
+Note that this will take some time to complete depending on the size of your database.
+We'll assume in our guide example that `docspelldb` is the name of your database:
+```bash
+pg_dump docspelldb > docspelldb_backup.sql
+```
+
+Optionally, once the docspell backup is complete you can 
+use `rsync` or `scp` to send `docspelldb_backup.sql` to a backup server.
+Now that you have known backup(s) of Docspell, you may one day have to restore a backup. 
+
+Let's test restoring a backup. You can start a PostgreSQL shell by using 
+the `psql` command as the `postgres` user or a PostgreSQL admin account. 
+If the database is corrupted or still exists, you will first need to remove it.
+Warning: By performing this next step you are *deleting* your database.
+```sql
+DROP DATABASE docspelldb;
+```
+
+And now we'll create a new database for your backup to restore to.
+Optionally, you can add UTF-8 encoding for better multilingual support.
+This example will assume the owner of the database is named `docspell`.
+```sql
+CREATE DATABASE docspelldb WITH OWNER = 'docspell' ENCODING = 'UTF8' template = 'template0';
+```
+
+Now that we have a new database, we can restore the backup.
+Exit your database with `\q` and in bash execute the following
+commands as the `postgres` or admin user.
+This command will also take some time to complete.
+```bash
+psql docspelldb < docspelldb_backup.sql
+```
+
+Now your database should be fully restored from your backup!
+Let's go to the Docspell server and restart the Docspell services.
+```bash
+sudo systemctl stop docspell-joex
+sudo systemctl stop docspell-restserver
+```
+
+If your database and owner are the same as your initial configuration,
+and you see your docspell data restored, you have sucessfully restored
+your PostgreSQL backup of Docspell manually.
 
 ### Fulltext Search
 
-Fulltext search is powered by [SOLR](https://solr.apache.org). You
-need to install solr and create a core for docspell. Then cange the
+Fulltext search can also be powered by [SOLR](https://solr.apache.org). 
+You need to install solr and create a core for docspell. Then cange the
 solr url for both components (restserver and joex) accordingly. See
-the relevant section in the [config
-page](@/docs/configure/fulltext-search.md).
-
+the relevant section in the [config page](@/docs/configure/fulltext-search.md).
 
 ### Watching a directory
 


### PR DESCRIPTION
This pull request is to resolve #2485 by providing technical documentation for the backup and restore process of the recommended database, PostgreSQL. 

I tried to reflect the current content style. Please let me know if any changes are needed to merge.