### PR TITLE
Change docker base images to 3.19.1

### DIFF
--- a/docker/dockerfiles/joex.dockerfile
+++ b/docker/dockerfiles/joex.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:20231219
+FROM alpine:3.19.1
 
 ARG version=
 ARG joex_url=

--- a/docker/dockerfiles/restserver.dockerfile
+++ b/docker/dockerfiles/restserver.dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:20231219
+FROM alpine:3.19.1
 
 ARG version=
 ARG restserver_url=


### PR DESCRIPTION
See #2504, alpine edge introduced a version of tesseract that is problematic to use from within docspell