### PR TITLE
Add package option to Nix modules

### DIFF
--- a/nix/modules/joex.nix
+++ b/nix/modules/joex.nix
@@ -306,6 +306,7 @@ in {
         default = false;
         description = "Whether to enable docspell docspell job executor.";
       };
+      package = mkPackageOption pkgs "docspell-joex" {};
       runAs = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -1777,7 +1778,7 @@ in {
 
     systemd.services.docspell-joex = let
       args = builtins.concatStringsSep " " cfg.jvmArgs;
-      cmd = "${pkgs.docspell-joex}/bin/docspell-joex ${args} -- ${configFile}";
+      cmd = "${lib.getExe' cfg.package "docspell-joex"} ${args} -- ${configFile}";
       waitTarget =
         if cfg.waitForTarget != null
         then [cfg.waitForTarget]

--- a/nix/modules/server.nix
+++ b/nix/modules/server.nix
@@ -150,6 +150,7 @@ in {
         default = false;
         description = "Whether to enable docspell.";
       };
+      package = mkPackageOption pkgs "docspell-restserver" {};
       runAs = mkOption {
         type = types.nullOr types.str;
         default = null;
@@ -878,7 +879,7 @@ in {
 
     systemd.services.docspell-restserver = let
       args = builtins.concatStringsSep " " cfg.jvmArgs;
-      cmd = "${pkgs.docspell-restserver}/bin/docspell-restserver ${args} -- ${configFile}";
+      cmd = "${lib.getExe' cfg.package "docspell-restserver"} ${args} -- ${configFile}";
     in {
       description = "Docspell Rest Server";
       after = ["networking.target"];


### PR DESCRIPTION
"Package" option allows specifying the derivation that will be used for the systemd service. Works the same way as `services.<name>.package` in NixOS. By default picks the docspell packages from pkgs instance -- same behavior as prior to this commit

Closes #2627