### PR TITLE
Move arg-mappings underneath `command` section

### DIFF
--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -593,27 +593,27 @@ Docpell Update Check
     # To convert image files to PDF files, tesseract is used. This
     # also extracts the text in one go.
     tesseract = {
-    # Custom Language Mappings Below
-    # Japanese Vertical Mapping
-    arg-mappings = {
-      "tesseract_lang" = {
-        value = "{{lang}}"
-        mappings = [
-          {
-            matches = "jpn_vert"
-            args = [ "-l", "jpn_vert", "-c", "preserve_interword_spaces=1" ]
-          },
-        # Start Other Custom Language Mappings Here
-        # Default Mapping Below
-          {
-            matches = ".*"
-            args = [ "-l", "{{lang}}" ] 
-          }
-        ]
-      }
-    }
       command = {
         program = "tesseract"
+        # Custom Language Mappings Below
+        # Japanese Vertical Mapping
+        arg-mappings = {
+          "tesseract_lang" = {
+            value = "{{lang}}"
+            mappings = [
+              {
+                matches = "jpn_vert"
+                args = [ "-l", "jpn_vert", "-c", "preserve_interword_spaces=1" ]
+              },
+            # Start Other Custom Language Mappings Here
+            # Default Mapping Below
+              {
+                matches = ".*"
+                args = [ "-l", "{{lang}}" ]
+              }
+            ]
+          }
+        }
         # Default arguments for all processing go below.
         args = [
           "{{infile}}",
@@ -667,29 +667,29 @@ Docpell Update Check
     # (where ocr is not necessary). In this case, the pdf will be
     # converted to PDF/A.
     ocrmypdf = {
-    # Custom argument mappings for this program.
-    arg-mappings = {
-      "ocr_lang" = {
-        value = "{{lang}}"
-        # Custom Language Mappings Below
-        # Japanese Vertical Mapping
-        mappings = [
-          {
-            matches = "jpn_vert"
-            args = [ "-l", "jpn_vert", "--pdf-renderer", "sandwich", "--tesseract-pagesegmode", "5" ]
-          },
-        # Start Other Custom Language Mappings Here
-        # Default Mapping Below
-          {
-            matches = ".*"
-            args = [ "-l", "{{lang}}" ]
-          }
-        ]
-      }
-    }
       enabled = true
       command = {
         program = "ocrmypdf"
+        # Custom argument mappings for this program.
+        arg-mappings = {
+          "ocr_lang" = {
+            value = "{{lang}}"
+            # Custom Language Mappings Below
+            # Japanese Vertical Mapping
+            mappings = [
+              {
+                matches = "jpn_vert"
+                args = [ "-l", "jpn_vert", "--pdf-renderer", "sandwich", "--tesseract-pagesegmode", "5" ]
+              },
+            # Start Other Custom Language Mappings Here
+            # Default Mapping Below
+              {
+                matches = ".*"
+                args = [ "-l", "{{lang}}" ]
+              }
+            ]
+          }
+        }
         # Default arguments for all processing go below.
         args = [
           "{{ocr_lang}}",


### PR DESCRIPTION
The argument mappings are part of the command configuration.

Small fixup for #2505 