### PR TITLE
Add Japanese Mapping for OCR Optimization

### DIFF
--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -679,7 +679,12 @@ Docpell Update Check
             mappings = [
               {
                 matches = "jpn_vert"
-                args = [ "-l", "jpn_vert", "--pdf-renderer", "sandwich", "--tesseract-pagesegmode", "5" ]
+                args = [ "-l", "jpn_vert", "--pdf-renderer", "sandwich", "--tesseract-pagesegmode", "5", "--output-type", "pdf" ]
+              },
+            # Japanese Mapping for OCR Optimization
+              {
+                matches = "jpn"
+                args = [ "-l", "jpn", "--output-type", "pdf" ]
               },
             # Start Other Custom Language Mappings Here
             # Default Mapping Below

--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -593,28 +593,8 @@ Docpell Update Check
     # To convert image files to PDF files, tesseract is used. This
     # also extracts the text in one go.
     tesseract = {
-    # Custom Language Mappings Below
-    # Japanese Vertical Mapping
-    arg-mappings = {
-      "tesseract_lang" = {
-        value = "{{lang}}"
-        mappings = [
-          {
-            matches = "jpn_vert"
-            args = [ "-l", "jpn_vert", "-c", "preserve_interword_spaces=1" ]
-          },
-        # Start Other Custom Language Mappings Here
-        # Default Mapping Below
-          {
-            matches = ".*"
-            args = [ "-l", "{{lang}}" ] 
-          }
-        ]
-      }
-    }
       command = {
         program = "tesseract"
-<<<<<<< HEAD
         # Custom Language Mappings Below
         # Japanese Vertical Mapping
         arg-mappings = {
@@ -634,8 +614,6 @@ Docpell Update Check
             ]
           }
         }
-=======
->>>>>>> 97fed73db0001342a4306bd720a6bd9106e9c911
         # Default arguments for all processing go below.
         args = [
           "{{infile}}",


### PR DESCRIPTION
This resolves #2667 item 2 to make better default compatibility for optical character recognition of CJK pdf documents. 