### PR TITLE
Nix module: secure config file

### DIFF
--- a/nix/modules/server.nix
+++ b/nix/modules/server.nix
@@ -12,11 +12,6 @@ with lib; let
     if cfg.runAs == null
     then "docspell"
     else cfg.runAs;
-  configFile = pkgs.writeText "docspell-restserver.conf" ''
-    {"docspell": {"server":
-      ${builtins.toJSON (lib.recursiveUpdate declared_config cfg.extraConfig)}
-    }}
-  '';
   defaults = {
     app-name = "Docspell";
     app-id = "rest1";
@@ -166,6 +161,15 @@ in {
         default = [];
         example = ["-J-Xmx1G"];
         description = "The options passed to the executable for setting jvm arguments.";
+      };
+      configFile = mkOption {
+        type = types.nullOr types.path;
+        default = null;
+        example = literalExpression ''"''${config.sops.secrets.docspell_restserver_config.path}"'';
+        description = ''
+          Path to an existing configuration file.
+          If null, a configuration file will be generated at /etc/docspell-restserver.conf
+        '';
       };
 
       app-name = mkOption {
@@ -897,8 +901,22 @@ in {
     };
     users.groups."${user}" = mkIf (cfg.runAs == null) {};
 
+    environment.etc."docspell-restserver.conf" = mkIf (cfg.configFile == null) {
+      text = ''
+        {"docspell": {"server":
+          ${builtins.toJSON (lib.recursiveUpdate declared_config cfg.extraConfig)}
+        }}
+      '';
+      user = user;
+      group = user;
+      mode = "0400";
+    };
+
     systemd.services.docspell-restserver = let
       args = builtins.concatStringsSep " " cfg.jvmArgs;
+      configFile = if cfg.configFile == null
+        then "/etc/docspell-restserver.conf"
+        else "${cfg.configFile}";
       cmd = "${lib.getExe' cfg.package "docspell-restserver"} ${args} -- ${configFile}";
     in {
       description = "Docspell Rest Server";


### PR DESCRIPTION
Update the NixOS module to handle config files more securely.

This addresses some of the low-hanging fruit identified in #2451 

#### 1) Stop writing config files to the world-readable nix store

Instead, write to `/etc/docspell-restserver.conf` and `/etc/docspell-joex.conf` readable only by the docspell user.

#### 2) Provide a `configFile` option

Allow the user to specify the path to a config file. They can use this to point to a file they've secured with their preferred secret management scheme (to avoid leaking sensitive info in the nixos configuration itself).

Only generate a config file if this option is left unspecified.
___

Example usage:
https://codeberg.org/ivanbrennan/nixos-config/commit/0d34b183dfe3e04421cb6044e67d974b83260630