### PR TITLE
Remove `--optimize-size` option from default weasyprint

### DIFF
--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -580,7 +580,6 @@ Docpell Update Check
       command = {
         program = "weasyprint"
         args = [
-          "--optimize-size", "all",
           "--encoding", "{{encoding}}",
           "-",
           "{{outfile}}"


### PR DESCRIPTION
Refs #2780