### PR TITLE
Fix sbt io version compatability

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,7 +1,10 @@
+// Get io version from environment or fall back to a known working version
+def ioVersion = sys.env.get("BUILD_VERSION")
+  .orElse(sys.props.get("sbt.build.version"))
+  .getOrElse("1.10.3")
+
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.4.3",
-  // sbt-native-packager and sbt-github-pages pull in an incompatible
-  // version of sbt-io which will break the build as soon as the
-  // sbt-bloop plugin is also present
-  "org.scala-sbt" %% "io" % sbtVersion.value
+  // Use the determined version instead of sbtVersion.value
+  "org.scala-sbt" %% "io" % ioVersion
 )


### PR DESCRIPTION
## Problem
The project was experiencing build issues due to version mismatches between SBT 1.10.7 and sbt-io dependencies. This was causing compatibility problems, particularly when using sbt-native-packager and sbt-github-pages plugins together with sbt-bloop.

## Solution
Implemented the same version resolution strategy that SBT itself uses in their codebase. https://github.com/sbt/sbt/blob/1.10.x/project/Dependencies.scala
This allows for:
- Flexible version resolution through environment variables
- Fallback to a known working version (1.10.3)
- Better compatibility with SBT plugins

## Changes
- Modified `project/build.sbt` to use SBT's version resolution strategy
- Added fallback to sbt-io 1.10.3 which is known to be stable and published
- Maintained compatibility with existing plugins