### PR TITLE
nix: unpin weasyprint from python310Packages

### DIFF
--- a/nix/modules/joex.nix
+++ b/nix/modules/joex.nix
@@ -188,7 +188,7 @@ with lib; let
 
       weasyprint = {
         command = {
-          program = "${pkgs.python310Packages.weasyprint}/bin/weasyprint";
+          program = "${pkgs.python3Packages.weasyprint}/bin/weasyprint";
           args = [
             "--optimize-images"
             "--encoding"


### PR DESCRIPTION
Using python310Packages.weasyprint causes weasyprint to be built every time the flake updates. Hydra (nixpkgs CI) builds weasyprint for the latest version of python and it's accessed under python3Packages.