### PR TITLE
Allow configuration of hikari pool size

### DIFF
--- a/modules/fts-psql/src/test/scala/docspell/ftspsql/PgFixtures.scala
+++ b/modules/fts-psql/src/test/scala/docspell/ftspsql/PgFixtures.scala
@@ -30,7 +30,7 @@ trait PgFixtures {
     )
 
   def jdbcConfig(cnt: PostgreSQLContainer): JdbcConfig =
-    JdbcConfig(LenientUri.unsafe(cnt.jdbcUrl), cnt.username, cnt.password)
+    JdbcConfig(LenientUri.unsafe(cnt.jdbcUrl), cnt.username, cnt.password, 10)
 
   def dataSource(cnt: PostgreSQLContainer): Resource[IO, DataSource] =
     StoreFixture.dataSource(jdbcConfig(cnt))

--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -54,7 +54,7 @@ docspell.joex {
     # The database password.
     password = ""
     # The default maximum pool size for hikari JDBC-backen (10 is the default of hikari)
-    maximum-pool-size =10
+    maximum-pool-size = 10
   }
 
   # Additional settings related to schema migration.
@@ -829,6 +829,7 @@ Docpell Update Check
         url = "jdbc:postgresql://server:5432/db"
         user = "pguser"
         password = ""
+        maximumpoolsize = 10
       }
 
       # A mapping from a language to a postgres text search config. By

--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -53,6 +53,8 @@ docspell.joex {
 
     # The database password.
     password = ""
+    # The default maximum pool size for hikari JDBC-backen (10 is the default of hikari)
+    maximum-pool-size =10
   }
 
   # Additional settings related to schema migration.

--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -829,7 +829,7 @@ Docpell Update Check
         url = "jdbc:postgresql://server:5432/db"
         user = "pguser"
         password = ""
-        maximumpoolsize = 10
+        maximum-pool-size = 10
       }
 
       # A mapping from a language to a postgres text search config. By

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -405,6 +405,8 @@ docspell.server {
 
       # The database password.
       password = ""
+      # The default maximum pool size for hikari JDBC-backen (10 is the default of hikari)
+      maximum-pool-size =10
     }
 
     # Additional settings related to schema migration.

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -356,6 +356,7 @@ docspell.server {
         url = "jdbc:postgresql://server:5432/db"
         user = "pguser"
         password = ""
+        maximum-pool-size = 10
       }
 
       # A mapping from a language to a postgres text search config. By
@@ -406,7 +407,7 @@ docspell.server {
       # The database password.
       password = ""
       # The default maximum pool size for hikari JDBC-backen (10 is the default of hikari)
-      maximum-pool-size =10
+      maximum-pool-size = 10
     }
 
     # Additional settings related to schema migration.

--- a/modules/store/src/main/scala/docspell/store/JdbcConfig.scala
+++ b/modules/store/src/main/scala/docspell/store/JdbcConfig.scala
@@ -8,7 +8,7 @@ package docspell.store
 
 import docspell.common.LenientUri
 
-case class JdbcConfig(url: LenientUri, user: String, password: String) {
+case class JdbcConfig(url: LenientUri, user: String, password: String, maximumPoolSize: Int = 10 ) {
 
   val dbms: Db =
     JdbcConfig.extractDbmsName(url).fold(sys.error, identity)

--- a/modules/store/src/main/scala/docspell/store/JdbcConfig.scala
+++ b/modules/store/src/main/scala/docspell/store/JdbcConfig.scala
@@ -8,7 +8,12 @@ package docspell.store
 
 import docspell.common.LenientUri
 
-case class JdbcConfig(url: LenientUri, user: String, password: String, maximumPoolSize: Int = 10 ) {
+case class JdbcConfig(
+    url: LenientUri,
+    user: String,
+    password: String,
+    maximumPoolSize: Int = 10
+) {
 
   val dbms: Db =
     JdbcConfig.extractDbmsName(url).fold(sys.error, identity)

--- a/modules/store/src/main/scala/docspell/store/JdbcConfig.scala
+++ b/modules/store/src/main/scala/docspell/store/JdbcConfig.scala
@@ -12,7 +12,7 @@ case class JdbcConfig(
     url: LenientUri,
     user: String,
     password: String,
-    maximumPoolSize: Int = 10
+    maximumPoolSize: Int
 ) {
 
   val dbms: Db =

--- a/modules/store/src/main/scala/docspell/store/Store.scala
+++ b/modules/store/src/main/scala/docspell/store/Store.scala
@@ -59,6 +59,7 @@ object Store {
         ds.setUsername(jdbc.user)
         ds.setPassword(jdbc.password)
         ds.setDriverClassName(jdbc.dbms.driverClass)
+        ds.setMaximumPoolSize(jdbc.maximumPoolSize)
       }
       logh = DoobieLogging[F](docspell.logging.getLogger[F])
       xa = HikariTransactor[F](ds, connectEC, Some(logh))

--- a/modules/store/src/test/scala/docspell/store/DatabaseTest.scala
+++ b/modules/store/src/test/scala/docspell/store/DatabaseTest.scala
@@ -111,7 +111,7 @@ trait DatabaseTest
 
 object DatabaseTest {
   private def jdbcConfig(cnt: JdbcDatabaseContainer) =
-    JdbcConfig(LenientUri.unsafe(cnt.jdbcUrl), cnt.username, cnt.password)
+    JdbcConfig(LenientUri.unsafe(cnt.jdbcUrl), cnt.username, cnt.password, 10)
 
   private def makeDataSourceFixture(cnt: IO[JdbcDatabaseContainer]) =
     for {

--- a/modules/store/src/test/scala/docspell/store/StoreFixture.scala
+++ b/modules/store/src/test/scala/docspell/store/StoreFixture.scala
@@ -53,7 +53,8 @@ object StoreFixture {
         s"jdbc:h2:mem:$dbname;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE;DB_CLOSE_DELAY=-1"
       ),
       "sa",
-      ""
+      "",
+      10
     )
 
   def fileDB(file: Path): JdbcConfig =
@@ -62,7 +63,8 @@ object StoreFixture {
         s"jdbc:h2:file://${file.absolute.toString};MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE"
       ),
       "sa",
-      ""
+      "",
+      10
     )
 
   def dataSource(jdbc: JdbcConfig): Resource[IO, DataSource] = {


### PR DESCRIPTION
This PR adds the option so specify the maximum pool size of db connections. Right now, the default by doobie of connection pool of 10 is being used, which can be too little in some multi user envoirments. 
Result: 
you now can specifiy in the config file e.g. `jdbc {maximum-pool-size = 20}``