### PR TITLE
Add env vars to docker addons

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -712,6 +712,19 @@ val joexapi = project
   )
   .dependsOn(common, loggingScribe, addonlib)
 
+val config = project
+  .in(file("modules/config"))
+  .disablePlugins(RevolverPlugin)
+  .settings(sharedSettings)
+  .withTestSettings
+  .settings(
+    name := "docspell-config",
+    libraryDependencies ++=
+      Dependencies.fs2 ++
+        Dependencies.pureconfig
+  )
+  .dependsOn(common, loggingApi, ftspsql, store, addonlib)
+
 val backend = project
   .in(file("modules/backend"))
   .disablePlugins(RevolverPlugin)
@@ -723,10 +736,12 @@ val backend = project
       Dependencies.fs2 ++
         Dependencies.bcrypt ++
         Dependencies.http4sClient ++
-        Dependencies.emil
+        Dependencies.emil ++
+        Dependencies.pureconfig
   )
   .dependsOn(
     addonlib,
+    config,
     store,
     notificationApi,
     joexapi,
@@ -770,20 +785,6 @@ val webapp = project
     openapiElmConfig := ElmConfig().withJson(ElmJson.decodePipeline)
   )
   .dependsOn(query.js)
-
-// Config project shared among the two applications only
-val config = project
-  .in(file("modules/config"))
-  .disablePlugins(RevolverPlugin)
-  .settings(sharedSettings)
-  .withTestSettings
-  .settings(
-    name := "docspell-config",
-    libraryDependencies ++=
-      Dependencies.fs2 ++
-        Dependencies.pureconfig
-  )
-  .dependsOn(common, loggingApi, ftspsql, store, addonlib)
 
 // --- Application(s)
 

--- a/modules/addonlib/src/main/scala/docspell/addons/AddonExecutor.scala
+++ b/modules/addonlib/src/main/scala/docspell/addons/AddonExecutor.scala
@@ -31,7 +31,8 @@ object AddonExecutor {
 
   def apply[F[_]: Async: Files](
       cfg: AddonExecutorConfig,
-      urlReader: UrlReader[F]
+      urlReader: UrlReader[F],
+      addonEnvResolver: String => Env = _ => Env.empty
   ): AddonExecutor[F] =
     new AddonExecutor[F] with AddonLoggerExtension {
       val config = cfg
@@ -99,8 +100,10 @@ object AddonExecutor {
             .compile
             .drain
 
+          addonEnv = addonEnvResolver(ctx.meta.meta.name)
+          mergedEnv = env.addAll(addonEnv)
           runner <- selectRunner(cfg, ctx.meta, ctx.addonDir)
-          result <- runner.run(logger, env, ctx)
+          result <- runner.run(logger, mergedEnv, ctx)
         } yield result
     }
 

--- a/modules/addonlib/src/test/scala/docspell/addons/AddonExecutorTest.scala
+++ b/modules/addonlib/src/test/scala/docspell/addons/AddonExecutorTest.scala
@@ -10,9 +10,9 @@ import cats.effect._
 import cats.syntax.all._
 
 import docspell.addons.out.AddonOutput
-import docspell.common.exec.Env
 import docspell.common.UrlReader
 import docspell.common.bc.{BackendCommand, ItemAction}
+import docspell.common.exec.Env
 import docspell.logging.{Level, TestLoggingConfig}
 
 import munit._

--- a/modules/addonlib/src/test/scala/docspell/addons/AddonExecutorTest.scala
+++ b/modules/addonlib/src/test/scala/docspell/addons/AddonExecutorTest.scala
@@ -10,6 +10,7 @@ import cats.effect._
 import cats.syntax.all._
 
 import docspell.addons.out.AddonOutput
+import docspell.common.exec.Env
 import docspell.common.UrlReader
 import docspell.common.bc.{BackendCommand, ItemAction}
 import docspell.logging.{Level, TestLoggingConfig}
@@ -106,6 +107,23 @@ class AddonExecutorTest extends CatsEffectSuite with Fixtures with TestLoggingCo
       assertEquals(res.addonResults.size, 2)
       assertEquals(res.addonResults.head, AddonResult.executionError(1))
       assertEquals(res.addonResults(1), AddonResult.success(testOut))
+    }
+  }
+
+  tempDir.test("inject env vars from addonEnvResolver") { dir =>
+    val addonEnvResolver: String => Env = {
+      case "env-test-addon" => Env.of("ADDON_FOO" -> "injected-value")
+      case _                => Env.empty
+    }
+    val cfg = testExecutorConfig(RunnerType.Trivial)
+    val exec =
+      AddonExecutor[IO](cfg, UrlReader.defaultReader, addonEnvResolver).execute(logger)
+    val addon = AddonGenerator.generate("env-test-addon", "1.0", collectOutput = false)(
+      """if [ "$ADDON_FOO" = "injected-value" ]; then exit 0; else exit 1; fi"""
+    )
+    val result = createInputEnv(dir, addon).use(exec.run)
+    result.map { res =>
+      assert(res.isSuccess, clue = res)
     }
   }
 

--- a/modules/backend/src/main/scala/docspell/backend/joex/AddonConfig.scala
+++ b/modules/backend/src/main/scala/docspell/backend/joex/AddonConfig.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Eike K. & Contributors
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package docspell.backend.joex
+
+/** Per-addon configuration for custom environment variables.
+  * Matched by addon name (AddonMeta.Meta.name).
+  */
+final case class AddonConfig(
+    name: String,
+    enabled: Boolean = true,
+    envs: List[AddonEnvVar] = Nil
+)
+
+/** A single environment variable to inject, with either direct value or valueFrom. */
+final case class AddonEnvVar(
+    name: String,
+    value: Option[String] = None,
+    valueFrom: Option[AddonEnvVarFrom] = None
+)
+
+/** Kubernetes-style valueFrom: read value from another source (e.g. process env). */
+final case class AddonEnvVarFrom(
+    env: Option[String] = None,
+    optional: Boolean = true
+)

--- a/modules/backend/src/main/scala/docspell/backend/joex/AddonConfig.scala
+++ b/modules/backend/src/main/scala/docspell/backend/joex/AddonConfig.scala
@@ -8,8 +8,8 @@ package docspell.backend.joex
 
 import docspell.common.exec.Env
 
-/** Per-addon configuration for custom environment variables.
-  * Matched by addon name (AddonMeta.Meta.name).
+/** Per-addon configuration for custom environment variables. Matched by addon name
+  * (AddonMeta.Meta.name).
   */
 final case class AddonConfig(
     name: String,
@@ -20,9 +20,10 @@ final case class AddonConfig(
   /** Resolve all env vars to an Env map. Only applies when enabled. */
   def toEnv: Env =
     if (!enabled) Env.empty
-    else envs.foldLeft(Env.empty) { (acc, ev) =>
-      ev.resolve.fold(acc)(kv => acc.add(kv._1, kv._2))
-    }
+    else
+      envs.foldLeft(Env.empty) { (acc, ev) =>
+        ev.resolve.fold(acc)(kv => acc.add(kv._1, kv._2))
+      }
 }
 
 /** A single environment variable to inject, with either direct value or valueFrom. */

--- a/modules/backend/src/main/scala/docspell/backend/joex/AddonConfig.scala
+++ b/modules/backend/src/main/scala/docspell/backend/joex/AddonConfig.scala
@@ -6,6 +6,8 @@
 
 package docspell.backend.joex
 
+import docspell.common.exec.Env
+
 /** Per-addon configuration for custom environment variables.
   * Matched by addon name (AddonMeta.Meta.name).
   */
@@ -13,14 +15,38 @@ final case class AddonConfig(
     name: String,
     enabled: Boolean = true,
     envs: List[AddonEnvVar] = Nil
-)
+) {
+
+  /** Resolve all env vars to an Env map. Only applies when enabled. */
+  def toEnv: Env =
+    if (!enabled) Env.empty
+    else envs.foldLeft(Env.empty) { (acc, ev) =>
+      ev.resolve.fold(acc)(kv => acc.add(kv._1, kv._2))
+    }
+}
 
 /** A single environment variable to inject, with either direct value or valueFrom. */
 final case class AddonEnvVar(
     name: String,
     value: Option[String] = None,
     valueFrom: Option[AddonEnvVarFrom] = None
-)
+) {
+
+  /** Resolve to Some((name, value)) or None if skipped. */
+  def resolve: Option[(String, String)] =
+    value match {
+      case Some(v) => Some(name -> v)
+      case None =>
+        valueFrom.flatMap(_.env) match {
+          case Some(envVar) =>
+            val fromEnv = System.getenv(envVar)
+            if (fromEnv != null) Some(name -> fromEnv)
+            else if (valueFrom.exists(!_.optional)) Some(name -> "")
+            else None
+          case None => None
+        }
+    }
+}
 
 /** Kubernetes-style valueFrom: read value from another source (e.g. process env). */
 final case class AddonEnvVarFrom(

--- a/modules/backend/src/main/scala/docspell/backend/joex/AddonEnvConfig.scala
+++ b/modules/backend/src/main/scala/docspell/backend/joex/AddonEnvConfig.scala
@@ -13,5 +13,6 @@ import docspell.addons.AddonExecutorConfig
 final case class AddonEnvConfig(
     workingDir: Path,
     cacheDir: Path,
-    executorConfig: AddonExecutorConfig
+    executorConfig: AddonExecutorConfig,
+    configs: List[AddonConfig] = Nil
 )

--- a/modules/backend/src/main/scala/docspell/backend/joex/AddonOps.scala
+++ b/modules/backend/src/main/scala/docspell/backend/joex/AddonOps.scala
@@ -170,8 +170,11 @@ object AddonOps {
           .ephemeralRun[F]
       } yield mm
 
-      def getExecutor(cfg: AddonExecutorConfig): F[AddonExecutor[F]] =
-        Async[F].pure(AddonExecutor(cfg, urlReader))
+      def getExecutor(execCfg: AddonExecutorConfig): F[AddonExecutor[F]] = {
+        val addonEnvResolver: String => Env = name =>
+          cfg.configs.find(_.name == name).fold(Env.empty)(_.toEnv)
+        Async[F].pure(AddonExecutor(execCfg, urlReader, addonEnvResolver))
+      }
 
       def findAddonRefs(
           collective: CollectiveId,

--- a/modules/backend/src/test/scala/docspell/backend/joex/AddonConfigTest.scala
+++ b/modules/backend/src/test/scala/docspell/backend/joex/AddonConfigTest.scala
@@ -6,6 +6,7 @@
 
 package docspell.backend.joex
 
+import docspell.common.exec.Env
 import docspell.config.Implicits._
 
 import pureconfig.ConfigSource
@@ -120,5 +121,45 @@ class AddonConfigTest extends FunSuite {
     assertEquals(cfg.configs.head.name, "postgres-addon")
     assertEquals(cfg.configs.head.envs.head.name, "PG_HOST")
     assertEquals(cfg.configs.head.envs.head.value, Some("localhost"))
+  }
+
+  test("AddonEnvVar.resolve with value") {
+    val ev = AddonEnvVar(name = "FOO", value = Some("bar"))
+    assertEquals(ev.resolve, Some("FOO" -> "bar"))
+  }
+
+  test("AddonEnvVar.resolve with valueFrom, optional=true, env unset") {
+    val ev = AddonEnvVar(
+      name = "SECRET",
+      valueFrom = Some(AddonEnvVarFrom(env = Some("DOCSPELL_ADDON_TEST_UNLIKELY_12345"), optional = true))
+    )
+    assertEquals(ev.resolve, None)
+  }
+
+  test("AddonEnvVar.resolve with valueFrom, optional=false, env unset") {
+    val ev = AddonEnvVar(
+      name = "REQUIRED",
+      valueFrom = Some(AddonEnvVarFrom(env = Some("DOCSPELL_ADDON_TEST_UNLIKELY_67890"), optional = false))
+    )
+    assertEquals(ev.resolve, Some("REQUIRED" -> ""))
+  }
+
+  test("AddonConfig.toEnv when disabled") {
+    val cfg = AddonConfig(name = "x", enabled = false, envs = List(AddonEnvVar("A", value = Some("a"))))
+    assertEquals(cfg.toEnv, Env.empty)
+  }
+
+  test("AddonConfig.toEnv when enabled") {
+    val cfg = AddonConfig(
+      name = "x",
+      enabled = true,
+      envs = List(
+        AddonEnvVar("A", value = Some("a")),
+        AddonEnvVar("B", value = Some("b"))
+      )
+    )
+    val env = cfg.toEnv
+    assertEquals(env.values.get("A"), Some("a"))
+    assertEquals(env.values.get("B"), Some("b"))
   }
 }

--- a/modules/backend/src/test/scala/docspell/backend/joex/AddonConfigTest.scala
+++ b/modules/backend/src/test/scala/docspell/backend/joex/AddonConfigTest.scala
@@ -9,10 +9,9 @@ package docspell.backend.joex
 import docspell.common.exec.Env
 import docspell.config.Implicits._
 
+import munit.FunSuite
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
-
-import munit.FunSuite
 
 class AddonConfigTest extends FunSuite {
 

--- a/modules/backend/src/test/scala/docspell/backend/joex/AddonConfigTest.scala
+++ b/modules/backend/src/test/scala/docspell/backend/joex/AddonConfigTest.scala
@@ -18,12 +18,12 @@ class AddonConfigTest extends FunSuite {
 
   test("parse AddonConfig from HOCON with value only") {
     val config = ConfigSource.string("""
-        |name = "my-addon"
-        |enabled = true
-        |envs = [
-        |  { name = "FOO", value = "bar" }
-        |]
-        |""".stripMargin)
+                                       |name = "my-addon"
+                                       |enabled = true
+                                       |envs = [
+                                       |  { name = "FOO", value = "bar" }
+                                       |]
+                                       |""".stripMargin)
     val result = config.at("").load[AddonConfig]
     assert(result.isRight, clue = result.left.map(_.toString))
     val cfg = result.toOption.get
@@ -36,27 +36,32 @@ class AddonConfigTest extends FunSuite {
   }
 
   test("parse AddonConfig from HOCON with valueFrom only") {
-    val config = ConfigSource.string("""
-        |name = "my-addon"
-        |enabled = true
-        |envs = [
-        |  {
-        |    name = "SECRET"
-        |    value-from = { env = "DS_SECRET", optional = true }
-        |  }
-        |]
-        |""".stripMargin)
+    val config =
+      ConfigSource.string("""
+                            |name = "my-addon"
+                            |enabled = true
+                            |envs = [
+                            |  {
+                            |    name = "SECRET"
+                            |    value-from = { env = "DS_SECRET", optional = true }
+                            |  }
+                            |]
+                            |""".stripMargin)
     val result = config.at("").load[AddonConfig]
     assert(result.isRight, clue = result.left.map(_.toString))
     val cfg = result.toOption.get
     assertEquals(cfg.envs.size, 1)
     assertEquals(cfg.envs.head.name, "SECRET")
     assertEquals(cfg.envs.head.value, None)
-    assertEquals(cfg.envs.head.valueFrom, Some(AddonEnvVarFrom(env = Some("DS_SECRET"), optional = true)))
+    assertEquals(
+      cfg.envs.head.valueFrom,
+      Some(AddonEnvVarFrom(env = Some("DS_SECRET"), optional = true))
+    )
   }
 
   test("parse AddonConfig with both value and valueFrom") {
-    val config = ConfigSource.string("""
+    val config = ConfigSource.string(
+      """
         |name = "my-addon"
         |envs = [
         |  {
@@ -65,16 +70,21 @@ class AddonConfigTest extends FunSuite {
         |    value-from = { env = "DS_MIXED", optional = false }
         |  }
         |]
-        |""".stripMargin)
+        |""".stripMargin
+    )
     val result = config.at("").load[AddonConfig]
     assert(result.isRight, clue = result.left.map(_.toString))
     val cfg = result.toOption.get
     assertEquals(cfg.envs.head.value, Some("direct"))
-    assertEquals(cfg.envs.head.valueFrom, Some(AddonEnvVarFrom(env = Some("DS_MIXED"), optional = false)))
+    assertEquals(
+      cfg.envs.head.valueFrom,
+      Some(AddonEnvVarFrom(env = Some("DS_MIXED"), optional = false))
+    )
   }
 
   test("parse AddonEnvConfig with empty addonConfigs") {
-    val config = ConfigSource.string("""
+    val config = ConfigSource.string(
+      """
         |working-dir = "/tmp/work"
         |cache-dir = "/tmp/cache"
         |executor-config {
@@ -85,7 +95,8 @@ class AddonConfigTest extends FunSuite {
         |  nix-runner = { nix-binary = "nix", build-timeout = "5 minutes" }
         |  docker-runner = { docker-binary = "docker", build-timeout = "5 minutes" }
         |}
-        |""".stripMargin)
+        |""".stripMargin
+    )
     val result = config.at("").load[AddonEnvConfig]
     assert(result.isRight, clue = result.left.map(_.toString))
     val cfg = result.toOption.get
@@ -93,7 +104,8 @@ class AddonConfigTest extends FunSuite {
   }
 
   test("parse AddonEnvConfig with non-empty addonConfigs") {
-    val config = ConfigSource.string("""
+    val config = ConfigSource.string(
+      """
         |working-dir = "/tmp/work"
         |cache-dir = "/tmp/cache"
         |executor-config {
@@ -113,7 +125,8 @@ class AddonConfigTest extends FunSuite {
         |    ]
         |  }
         |]
-        |""".stripMargin)
+        |""".stripMargin
+    )
     val result = config.at("").load[AddonEnvConfig]
     assert(result.isRight, clue = result.left.map(_.toString))
     val cfg = result.toOption.get
@@ -131,7 +144,9 @@ class AddonConfigTest extends FunSuite {
   test("AddonEnvVar.resolve with valueFrom, optional=true, env unset") {
     val ev = AddonEnvVar(
       name = "SECRET",
-      valueFrom = Some(AddonEnvVarFrom(env = Some("DOCSPELL_ADDON_TEST_UNLIKELY_12345"), optional = true))
+      valueFrom = Some(
+        AddonEnvVarFrom(env = Some("DOCSPELL_ADDON_TEST_UNLIKELY_12345"), optional = true)
+      )
     )
     assertEquals(ev.resolve, None)
   }
@@ -139,13 +154,22 @@ class AddonConfigTest extends FunSuite {
   test("AddonEnvVar.resolve with valueFrom, optional=false, env unset") {
     val ev = AddonEnvVar(
       name = "REQUIRED",
-      valueFrom = Some(AddonEnvVarFrom(env = Some("DOCSPELL_ADDON_TEST_UNLIKELY_67890"), optional = false))
+      valueFrom = Some(
+        AddonEnvVarFrom(
+          env = Some("DOCSPELL_ADDON_TEST_UNLIKELY_67890"),
+          optional = false
+        )
+      )
     )
     assertEquals(ev.resolve, Some("REQUIRED" -> ""))
   }
 
   test("AddonConfig.toEnv when disabled") {
-    val cfg = AddonConfig(name = "x", enabled = false, envs = List(AddonEnvVar("A", value = Some("a"))))
+    val cfg = AddonConfig(
+      name = "x",
+      enabled = false,
+      envs = List(AddonEnvVar("A", value = Some("a")))
+    )
     assertEquals(cfg.toEnv, Env.empty)
   }
 

--- a/modules/backend/src/test/scala/docspell/backend/joex/AddonConfigTest.scala
+++ b/modules/backend/src/test/scala/docspell/backend/joex/AddonConfigTest.scala
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2020 Eike K. & Contributors
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package docspell.backend.joex
+
+import docspell.config.Implicits._
+
+import pureconfig.ConfigSource
+import pureconfig.generic.auto._
+
+import munit.FunSuite
+
+class AddonConfigTest extends FunSuite {
+
+  test("parse AddonConfig from HOCON with value only") {
+    val config = ConfigSource.string("""
+        |name = "my-addon"
+        |enabled = true
+        |envs = [
+        |  { name = "FOO", value = "bar" }
+        |]
+        |""".stripMargin)
+    val result = config.at("").load[AddonConfig]
+    assert(result.isRight, clue = result.left.map(_.toString))
+    val cfg = result.toOption.get
+    assertEquals(cfg.name, "my-addon")
+    assertEquals(cfg.enabled, true)
+    assertEquals(cfg.envs.size, 1)
+    assertEquals(cfg.envs.head.name, "FOO")
+    assertEquals(cfg.envs.head.value, Some("bar"))
+    assertEquals(cfg.envs.head.valueFrom, None)
+  }
+
+  test("parse AddonConfig from HOCON with valueFrom only") {
+    val config = ConfigSource.string("""
+        |name = "my-addon"
+        |enabled = true
+        |envs = [
+        |  {
+        |    name = "SECRET"
+        |    value-from = { env = "DS_SECRET", optional = true }
+        |  }
+        |]
+        |""".stripMargin)
+    val result = config.at("").load[AddonConfig]
+    assert(result.isRight, clue = result.left.map(_.toString))
+    val cfg = result.toOption.get
+    assertEquals(cfg.envs.size, 1)
+    assertEquals(cfg.envs.head.name, "SECRET")
+    assertEquals(cfg.envs.head.value, None)
+    assertEquals(cfg.envs.head.valueFrom, Some(AddonEnvVarFrom(env = Some("DS_SECRET"), optional = true)))
+  }
+
+  test("parse AddonConfig with both value and valueFrom") {
+    val config = ConfigSource.string("""
+        |name = "my-addon"
+        |envs = [
+        |  {
+        |    name = "MIXED"
+        |    value = "direct"
+        |    value-from = { env = "DS_MIXED", optional = false }
+        |  }
+        |]
+        |""".stripMargin)
+    val result = config.at("").load[AddonConfig]
+    assert(result.isRight, clue = result.left.map(_.toString))
+    val cfg = result.toOption.get
+    assertEquals(cfg.envs.head.value, Some("direct"))
+    assertEquals(cfg.envs.head.valueFrom, Some(AddonEnvVarFrom(env = Some("DS_MIXED"), optional = false)))
+  }
+
+  test("parse AddonEnvConfig with empty addonConfigs") {
+    val config = ConfigSource.string("""
+        |working-dir = "/tmp/work"
+        |cache-dir = "/tmp/cache"
+        |executor-config {
+        |  runner = "trivial"
+        |  run-timeout = "5 minutes"
+        |  fail-fast = true
+        |  nspawn = { enabled = false, sudo-binary = "sudo", nspawn-binary = "nspawn", container-wait = "100 millis" }
+        |  nix-runner = { nix-binary = "nix", build-timeout = "5 minutes" }
+        |  docker-runner = { docker-binary = "docker", build-timeout = "5 minutes" }
+        |}
+        |""".stripMargin)
+    val result = config.at("").load[AddonEnvConfig]
+    assert(result.isRight, clue = result.left.map(_.toString))
+    val cfg = result.toOption.get
+    assertEquals(cfg.configs, Nil)
+  }
+
+  test("parse AddonEnvConfig with non-empty addonConfigs") {
+    val config = ConfigSource.string("""
+        |working-dir = "/tmp/work"
+        |cache-dir = "/tmp/cache"
+        |executor-config {
+        |  runner = "trivial"
+        |  run-timeout = "5 minutes"
+        |  fail-fast = true
+        |  nspawn = { enabled = false, sudo-binary = "sudo", nspawn-binary = "nspawn", container-wait = "100 millis" }
+        |  nix-runner = { nix-binary = "nix", build-timeout = "5 minutes" }
+        |  docker-runner = { docker-binary = "docker", build-timeout = "5 minutes" }
+        |}
+        |configs = [
+        |  {
+        |    name = "postgres-addon"
+        |    enabled = true
+        |    envs = [
+        |      { name = "PG_HOST", value = "localhost" }
+        |    ]
+        |  }
+        |]
+        |""".stripMargin)
+    val result = config.at("").load[AddonEnvConfig]
+    assert(result.isRight, clue = result.left.map(_.toString))
+    val cfg = result.toOption.get
+    assertEquals(cfg.configs.size, 1)
+    assertEquals(cfg.configs.head.name, "postgres-addon")
+    assertEquals(cfg.configs.head.envs.head.name, "PG_HOST")
+    assertEquals(cfg.configs.head.envs.head.value, Some("localhost"))
+  }
+}

--- a/modules/config/src/test/scala/docspell/config/EnvConfigTest.scala
+++ b/modules/config/src/test/scala/docspell/config/EnvConfigTest.scala
@@ -55,6 +55,9 @@ class EnvConfigTest extends FunSuite {
     assertEquals(cfg.getString("docspell.joex.addons.configs.0.name"), "postgres-addon")
     assertEquals(cfg.getBoolean("docspell.joex.addons.configs.0.enabled"), true)
     assertEquals(cfg.getString("docspell.joex.addons.configs.0.envs.0.name"), "PG_HOST")
-    assertEquals(cfg.getString("docspell.joex.addons.configs.0.envs.0.value"), "localhost")
+    assertEquals(
+      cfg.getString("docspell.joex.addons.configs.0.envs.0.value"),
+      "localhost"
+    )
   }
 }

--- a/modules/config/src/test/scala/docspell/config/EnvConfigTest.scala
+++ b/modules/config/src/test/scala/docspell/config/EnvConfigTest.scala
@@ -42,4 +42,19 @@ class EnvConfigTest extends FunSuite {
     val cfg = EnvConfig.loadFrom(Map("A_B_C" -> "12").view)
     assert(!cfg.hasPath("a.b.c"))
   }
+
+  test("override addons.configs via env vars") {
+    val cfg = EnvConfig.loadFrom(
+      Map(
+        "DOCSPELL_JOEX_ADDONS_CONFIGS_0_NAME" -> "postgres-addon",
+        "DOCSPELL_JOEX_ADDONS_CONFIGS_0_ENABLED" -> "true",
+        "DOCSPELL_JOEX_ADDONS_CONFIGS_0_ENVS_0_NAME" -> "PG_HOST",
+        "DOCSPELL_JOEX_ADDONS_CONFIGS_0_ENVS_0_VALUE" -> "localhost"
+      ).view
+    )
+    assertEquals(cfg.getString("docspell.joex.addons.configs.0.name"), "postgres-addon")
+    assertEquals(cfg.getBoolean("docspell.joex.addons.configs.0.enabled"), true)
+    assertEquals(cfg.getString("docspell.joex.addons.configs.0.envs.0.name"), "PG_HOST")
+    assertEquals(cfg.getString("docspell.joex.addons.configs.0.envs.0.value"), "localhost")
+  }
 }

--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -879,8 +879,9 @@ Docpell Update Check
     # ]
     #
     # For each env: use "value" for a literal, or "value-from" to read from
-    # the process environment. With value-from.env, optional=true skips the
-    # variable when unset; optional=false injects empty string when unset.
+    # the process environment. In value-from: "env" is the source variable
+    # name; "optional" (default: true) controls behavior when the source is
+    # unset: true = skip the variable; false = inject empty string.
     configs = []
 
     # A directory to extract addons when running them. Everything in

--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -863,7 +863,24 @@ Docpell Update Check
   }
 
   addons {
-    # Per-addon environment variable configuration. Keyed by addon name.
+    # Per-addon environment variable configuration. Each entry is matched by
+    # addon name (from the addon descriptor). Environment variables are
+    # injected when the addon runs. Example:
+    #
+    # configs = [
+    #   {
+    #     name = "postgres-addon"
+    #     enabled = true
+    #     envs = [
+    #       { name = "PG_HOST", value = "localhost" }
+    #       { name = "PG_PASS", value-from = { env = "DS_PG_PASS", optional = true } }
+    #     ]
+    #   }
+    # ]
+    #
+    # For each env: use "value" for a literal, or "value-from" to read from
+    # the process environment. With value-from.env, optional=true skips the
+    # variable when unset; optional=false injects empty string when unset.
     configs = []
 
     # A directory to extract addons when running them. Everything in

--- a/modules/joex/src/main/resources/reference.conf
+++ b/modules/joex/src/main/resources/reference.conf
@@ -863,6 +863,9 @@ Docpell Update Check
   }
 
   addons {
+    # Per-addon environment variable configuration. Keyed by addon name.
+    configs = []
+
     # A directory to extract addons when running them. Everything in
     # here will be cleared after each run.
     working-dir = ${java.io.tmpdir}"/docspell-addons"

--- a/project/ZolaPlugin.scala
+++ b/project/ZolaPlugin.scala
@@ -38,8 +38,7 @@ object ZolaPlugin extends AutoPlugin {
       zolaBuild := {
         val logger = streams.value.log
         logger.info("Building web site using zola ...")
-        (Compile / resources).value
-        zolaPrepare.value
+        val _ = ((Compile / resources).value, zolaPrepare.value)
         buildSite(zolaCommand.value, zolaRootDir.value, zolaOutputDir.value, None, logger)
         logger.info("Website built")
       },
@@ -47,8 +46,7 @@ object ZolaPlugin extends AutoPlugin {
         val logger = streams.value.log
         val baseurl = zolaTestBaseUrl.value
         logger.info("Building web site (test) using zola ...")
-        (Compile / resources).value
-        zolaPrepare.value
+        val _ = ((Compile / resources).value, zolaPrepare.value)
         buildSite(
           zolaCommand.value,
           zolaRootDir.value,

--- a/website/site/content/docs/addons/control.md
+++ b/website/site/content/docs/addons/control.md
@@ -81,6 +81,36 @@ runner (possibly in combination with `systemd-nspawn`) can be used.
 
 # Runtime
 
+## Environment variables
+
+You can inject custom environment variables into addons via
+`addons.configs` in the joex config. Each entry is matched by addon
+name (from the addon descriptor). This is useful for passing secrets
+(e.g. API keys) or connection details (e.g. database host) without
+hardcoding them in run configurations.
+
+Example:
+
+```hocon
+addons {
+  configs = [
+    {
+      name = "postgres-addon"
+      enabled = true
+      envs = [
+        { name = "PG_HOST", value = "localhost" }
+        { name = "PG_PASS", value-from = { env = "DS_PG_PASS", optional = true } }
+      ]
+    }
+  ]
+}
+```
+
+For each variable use `value` for a literal string, or `value-from` to
+read from the process environment. With `value-from.env` and
+`optional = true`, the variable is skipped when unset; with
+`optional = false`, an empty string is injected when unset.
+
 ## Cache directory
 
 Addons can use a "cache directory" to store data between runs. This

--- a/website/site/content/docs/addons/control.md
+++ b/website/site/content/docs/addons/control.md
@@ -91,7 +91,7 @@ hardcoding them in run configurations.
 
 Example:
 
-```hocon
+```conf
 addons {
   configs = [
     {

--- a/website/site/content/docs/addons/control.md
+++ b/website/site/content/docs/addons/control.md
@@ -107,9 +107,13 @@ addons {
 ```
 
 For each variable use `value` for a literal string, or `value-from` to
-read from the process environment. With `value-from.env` and
-`optional = true`, the variable is skipped when unset; with
-`optional = false`, an empty string is injected when unset.
+read from the process environment. In `value-from`, `env` is the source
+variable name. The `optional` flag (default: `true`) controls behavior when
+the source is unset: `true` skips the variable; `false` injects an empty
+string. Use `optional = false` when the addon expects the variable to
+always exist.
+
+To try this out, use the [docspell-addon-example](https://github.com/tiborrr/docspell-addon-example). It logs all `DOCSPELL_TEST_*` env vars to stderr. Add a config for `docspell-addon-example` with env vars like `DOCSPELL_TEST_FOO` and `DOCSPELL_TEST_BAZ`, then run the addon and check the joex logs.
 
 ## Cache directory
 

--- a/website/site/content/docs/addons/using.md
+++ b/website/site/content/docs/addons/using.md
@@ -24,6 +24,10 @@ addon:
 
 - <https://github.com/docspell/rotate-pdf-addon/archive/refs/tags/v0.1.0.zip>
 
+The [docspell-addon-example](https://github.com/tiborrr/docspell-addon-example) is a minimal reference addon that logs all context Docspell provides (user input, env vars, item data). Useful for testing and as a template:
+
+- <https://github.com/tiborrr/docspell-addon-example/releases/latest/download/docspell-addon-example.zip>
+
 This url points to a fixed version. It is also possible to use urls
 that are "moving targets":
 


### PR DESCRIPTION
# Add support for addon-specific environment variables

Closes #2896

## Summary

Add server-level configuration to inject custom environment variables into addons. Configs are keyed by addon name and support direct values or reading from the process environment.

## Configuration

```hocon
docspell.joex.addons {
  configs = [
    {
      name = "my-postgres-addon"
      enabled = true
      envs = [
        { name = "POSTGRES_HOST", value = "localhost" }
        { name = "POSTGRES_PASSWORD", value-from = { env = "DS_POSTGRES_PASSWORD", optional = true } }
      ]
    }
  ]
}
```

- `value`: literal string
- `value-from`: read from process env. `env` = source variable name; `optional` (default: true) — when source unset: true = skip, false = inject empty string

## Environment variable override

```bash
DOCSPELL_JOEX_ADDONS_CONFIGS_0_NAME="my-postgres-addon"
DOCSPELL_JOEX_ADDONS_CONFIGS_0_ENVS_0_NAME="POSTGRES_HOST"
DOCSPELL_JOEX_ADDONS_CONFIGS_0_ENVS_0_VALUE="localhost"
```

## Running example

Use [docspell-addon-example](https://github.com/tiborrr/docspell-addon-example) — it logs all `DOCSPELL_TEST_*` env vars to stderr.

Used config:

```hocon
# Development config - picked up by sbt when present
# Binds to 0.0.0.0 so the app is reachable from Windows when running in WSL2

docspell.server {
  bind {
    address = "0.0.0.0"
    port = 7880
  }
  backend {
    addons {
      enabled = true
      allow-impure = true
      allowed-urls = "*"
      denied-urls = ""
    }
  }
}

docspell.joex {
  bind {
    address = "0.0.0.0"
    port = 7878
  }
  addons {
    # Example: inject env vars for docspell-addon-example (prints DOCSPELL_TEST_* to stderr)
    configs = [
      {
        name = "docspell-addon-example"
        enabled = true
        envs = [
          { name = "DOCSPELL_TEST_FOO", value = "bar" }
          # value-from: read from process env (e.g. export DS_TEST_BAZ=secret before starting joex)
          { name = "DOCSPELL_TEST_BAZ", value-from = { env = "DS_TEST_BAZ", optional = true } }
        ]
      }
    ]
  }
}
```

<img width="817" height="260" alt="image" src="https://github.com/user-attachments/assets/36c8ee8e-c589-471e-bb2f-d7582b32ca3b" />

<img width="712" height="113" alt="image" src="https://github.com/user-attachments/assets/64254d01-8b4f-45a5-b4d9-47aa4bec32b1" />

<img width="1400" height="909" alt="image" src="https://github.com/user-attachments/assets/6a061c77-83b9-4bb4-9852-db507af69aa3" />

