### PR TITLE
feat: add optional `priority` to upload metadata

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 🚀 Features
+
+- Add optional `priority` field to upload metadata (`ItemUploadMeta`) for setting job processing priority per upload
+
 ## v0.43.0
 
 *Mar 15, 2025*

--- a/modules/backend/src/main/scala/docspell/backend/ops/OUpload.scala
+++ b/modules/backend/src/main/scala/docspell/backend/ops/OUpload.scala
@@ -72,7 +72,8 @@ object OUpload {
       language: Option[Language],
       attachmentsOnly: Option[Boolean],
       flattenArchives: Option[Boolean],
-      customData: Option[Json]
+      customData: Option[Json],
+      priority: Option[Priority]
   )
 
   case class UploadData[F[_]](
@@ -199,7 +200,7 @@ object OUpload {
               attachmentsOnly =
                 data.meta.attachmentsOnly.orElse(src.source.attachmentsOnly.some)
             ),
-            priority = src.source.priority
+            priority = data.meta.priority.getOrElse(src.source.priority)
           )
           result <- OptionT.liftF(submit(updata, src.source.cid, None, itemId))
         } yield result).getOrElse(UploadResult.noSource)

--- a/modules/joex/src/main/scala/docspell/joex/scanmailbox/ScanMailboxTask.scala
+++ b/modules/joex/src/main/scala/docspell/joex/scanmailbox/ScanMailboxTask.scala
@@ -329,6 +329,7 @@ object ScanMailboxTask {
           args.language,
           args.attachmentsOnly,
           None,
+          None,
           None
         )
         data = OUpload.UploadData(

--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -8271,6 +8271,16 @@ components:
             Custom user data that gets threaded through the processing. Docspell
             ignores it completely, but will pass it to the outcome of processing
             to be able to react on it in addons or other ways.
+        priority:
+          type: string
+          format: priority
+          enum:
+            - high
+            - low
+          description: |
+            Processing priority for the upload jobs. If omitted, the endpoint
+            default applies (high for secured upload, source priority for open
+            upload, server config for integration).
 
     Collective:
       description: |

--- a/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
@@ -316,7 +316,8 @@ trait Conversions {
               m.language,
               m.attachmentsOnly,
               m.flattenArchives,
-              m.customData
+              m.customData,
+              m.priority
             )
           )
         )
@@ -332,6 +333,7 @@ trait Conversions {
             skipDuplicates = false,
             Glob.all,
             Nil,
+            None,
             None,
             None,
             None,
@@ -355,7 +357,13 @@ trait Conversions {
       metaData <- meta
       _ <- Async[F].delay(logger.debug(s"Parsed upload meta data: $metaData"))
       tracker <- Ident.randomId[F]
-    } yield UploadData(metaData._1, metaData._2, files, prio, Some(tracker))
+    } yield UploadData(
+      metaData._1,
+      metaData._2,
+      files,
+      metaData._2.priority.getOrElse(prio),
+      Some(tracker)
+    )
   }
 
   // organization and person

--- a/modules/webapp/src/main/elm/Comp/UploadForm.elm
+++ b/modules/webapp/src/main/elm/Comp/UploadForm.elm
@@ -16,6 +16,7 @@ import Comp.Progress
 import Data.DropdownStyle as DS
 import Data.Flags exposing (Flags)
 import Data.Language exposing (Language)
+import Data.Priority exposing (Priority)
 import Data.UiSettings exposing (UiSettings)
 import Dict exposing (Dict)
 import File exposing (File)
@@ -43,6 +44,8 @@ type alias Model =
     , skipDuplicates : Bool
     , languageModel : Comp.FixedDropdown.Model Language
     , language : Maybe Language
+    , priorityModel : Comp.FixedDropdown.Model Priority
+    , priority : Priority
     , flattenArchives : Bool
     , uploadDone : Maybe Bool
     }
@@ -58,6 +61,7 @@ type Msg
     | DropzoneMsg Comp.Dropzone.Msg
     | ToggleSkipDuplicates
     | LanguageMsg (Comp.FixedDropdown.Msg Language)
+    | PrioDropdownMsg (Comp.FixedDropdown.Msg Priority)
     | ToggleFlattenArchives
 
 
@@ -74,6 +78,9 @@ init =
     , languageModel =
         Comp.FixedDropdown.init Data.Language.all
     , language = Nothing
+    , priorityModel =
+        Comp.FixedDropdown.init Data.Priority.all
+    , priority = Data.Priority.High
     , flattenArchives = False
     , uploadDone = Nothing
     }
@@ -192,6 +199,7 @@ update sourceId flags msg model =
                                 Just "outgoing"
                         , language = Maybe.map Data.Language.toIso3 model.language
                         , flattenArchives = Just model.flattenArchives
+                        , priority = Just (Data.Priority.toName model.priority)
                     }
 
                 fileids =
@@ -342,6 +350,19 @@ update sourceId flags msg model =
             , Sub.none
             )
 
+        PrioDropdownMsg pm ->
+            let
+                ( m2, p2 ) =
+                    Comp.FixedDropdown.update pm model.priorityModel
+            in
+            ( { model
+                | priorityModel = m2
+                , priority = Maybe.withDefault model.priority p2
+              }
+            , Cmd.none
+            , Sub.none
+            )
+
 
 setCompleted : Model -> String -> Set String
 setCompleted model fileid =
@@ -428,6 +449,13 @@ renderForm texts model =
             , style = DS.mainStyleWith "w-40"
             , selectPlaceholder = texts.basics.selectPlaceholder
             }
+
+        priorityCfg =
+            { display = Data.Priority.toName
+            , icon = \_ -> Nothing
+            , style = DS.mainStyleWith "w-40"
+            , selectPlaceholder = texts.basics.selectPlaceholder
+            }
     in
     div [ class "row" ]
         [ Html.form [ action "#" ]
@@ -508,6 +536,21 @@ renderForm texts model =
                     ]
                 , div [ class "text-gray-400 text-xs" ]
                     [ text texts.languageInfo
+                    ]
+                ]
+            , div [ class "flex flex-col mb-3" ]
+                [ label [ class "inline-flex items-center mb-2" ]
+                    [ span [ class "mr-2" ] [ text (texts.priority ++ ":") ]
+                    , Html.map PrioDropdownMsg
+                        (Comp.FixedDropdown.viewStyled2
+                            priorityCfg
+                            False
+                            (Just model.priority)
+                            model.priorityModel
+                        )
+                    ]
+                , div [ class "text-gray-400 text-xs" ]
+                    [ text texts.priorityInfo
                     ]
                 ]
             ]

--- a/modules/webapp/src/main/elm/Messages/Comp/UploadForm.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/UploadForm.elm
@@ -36,6 +36,8 @@ type alias Texts =
     , selectedFiles : String
     , languageLabel : Language -> String
     , flattenArchives : String
+    , priority : String
+    , priorityInfo : String
     }
 
 
@@ -67,6 +69,8 @@ gb =
     , selectedFiles = "Selected Files"
     , languageLabel = Messages.Data.Language.gb
     , flattenArchives = "Extract zip file contents into separate items, in contrast to a single document with multiple attachments."
+    , priority = "Priority"
+    , priorityInfo = "The priority used by the scheduler when processing uploaded files."
     }
 
 
@@ -98,6 +102,8 @@ de =
     , selectedFiles = "Ausgewählte Dateien"
     , languageLabel = Messages.Data.Language.de
     , flattenArchives = "ZIP Dateien in separate Dokumente entpacken, anstatt ein Dokument mit mehreren Anhängen."
+    , priority = "Priorität"
+    , priorityInfo = "Die Priorität, die für die Hintergrundaufgabe zur Verarbeitung verwendet wird."
     }
 
 
@@ -129,4 +135,6 @@ fr =
     , selectedFiles = "Fichiers séléctionnés"
     , languageLabel = Messages.Data.Language.fr
     , flattenArchives = "Décompresser les fichiers ZIP dans des documents séparés au lieu de créer un document avec plusieurs pièces jointes."
+    , priority = "Priorité"
+    , priorityInfo = "Ordre de priorité utilisé par le programmateur lors du traitement des fichiers envoyés."
     }

--- a/website/site/content/docs/api/upload.md
+++ b/website/site/content/docs/api/upload.md
@@ -54,6 +54,7 @@ specified via a JSON structure in a part with name `meta`:
 , language: Maybe String
 , attachmentsOnly: Maybe Bool
 , flattenArchives: Maybe Bool
+, priority: Maybe String
 }
 ```
 
@@ -109,6 +110,13 @@ specified via a JSON structure in a part with name `meta`:
   only its contents are. Also note that only the uploaded archive
   files are extracted once (not recursively), so if it contains other
   archive files, they are treated as normal.
+- The `priority` field sets the processing priority for the upload
+  jobs. It can be `high` or `low` and controls how soon the scheduler
+  picks up the jobs relative to other work. If omitted, the endpoint
+  default applies: `high` for authenticated (webapp) uploads, the
+  source's configured priority for open uploads via a source URL, and
+  the server configuration for the integration endpoint. When
+  specified, it overrides the source's default priority.
 
 # Endpoints
 


### PR DESCRIPTION
<img width="1554" height="896" alt="image" src="https://github.com/user-attachments/assets/27fbaeae-87a0-4c89-af75-bfa32bfe45d3" />

---

## Summary

- Add optional `priority` field (`high` | `low`) to upload `meta` JSON (`ItemUploadMeta`)
- Allow API clients and the webapp to set processing priority per upload
- Document the field in OpenAPI, upload docs, and Changelog

## Motivation

I have to migrate a few thousand documents to Docspell, but do not want to clog the upload queue.

Upload priority was previously fixed by endpoint:

| Endpoint | Default priority |
|----------|------------------|
| Authenticated (`/api/v1/sec/upload/item`) | `high` |
| Open source URL (`/api/v1/open/upload/item/{sourceId}`) | Source’s configured priority |
| Integration (`/api/v1/open/integration/item/{collective}`) | Server config |

There was no way to set priority per request. This adds per-upload control while keeping existing defaults when `priority` is omitted.

## Changes

**Backend**
- Extend `OUpload.UploadMeta` with `priority: Option[Priority]`
- `readMultipart`: use `meta.priority` when set, otherwise endpoint default
- Open uploads via source: `meta.priority` overrides source default when provided

**Webapp**
- Priority dropdown on upload form (defaults to **High**)
- Sends `priority` in upload metadata

**Docs / API**
- OpenAPI: `priority` on `ItemUploadMeta`
- Upload API docs updated
- Changelog entry under Unreleased

## API example

```bash
curl -XPOST \
  -H "X-Docspell-Auth: …" \
  -F 'meta={"multiple":true,"priority":"low"}' \
  -F file=@invoice.pdf \
  http://localhost:7880/api/v1/sec/upload/item
```

## Backward compatibility

Fully backward compatible. Omitted `priority` keeps current behavior on all endpoints.

## Manual verification

Tested locally against `sbt reStart` (H2, collective `ets`, user `ets/admin`) via `/api/v1/sec/upload/item`:

| Upload | `meta.priority` | Job priority | Result |
|--------|-----------------|--------------|--------|
| `2026-04-15_AT2600707.pdf` | *(omitted)* | **High** | success (~1s) |
| `2026-04-15_AT2600723.pdf` | `"low"` | **Low** | success (~1s) |
| `2026-04-15_AT2600725.pdf` | `"high"` | **High** | success (~1s) |

<img width="2249" height="245" alt="image" src="https://github.com/user-attachments/assets/437553f1-ff3e-471f-9b09-4c0ff301523a" />



All three returned `{"success":true,"message":"Files submitted."}`. Queue UI and joex logs matched expected priorities (`process-item/High` vs `process-item/Low`). DB job records: priority `10` (high) for default and explicit high; `0` (low) for explicit low.

Default secured upload without `priority` correctly uses **high**.