### PR TITLE
Feat/upload api immediate document

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 🚀 Features
+
+- Add optional `priority` field to upload metadata (`ItemUploadMeta`) for setting job processing priority per upload
+
 ## v0.43.0
 
 *Mar 15, 2025*

--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@
 
 ### 🚀 Features
 
+- Upload endpoints now return `fileKeys` and `jobIds` so clients can track
+  submitted files and processing jobs immediately.
+- Add secured endpoint to download files by file key for retrieving uploaded
+  bytes before processing finishes.
 - Add `statsProfile` to search stats (`full`, `general`, `fields`). The
   dashboard uses lighter `general` and `fields` requests instead of
   repeating the full statistics query.

--- a/build.sbt
+++ b/build.sbt
@@ -748,14 +748,15 @@ val backend = project
   .dependsOn(
     addonlib,
     config,
-    store,
+    store % "compile->compile;test->test",
     notificationApi,
     joexapi,
     ftsclient,
     totp,
     pubsubApi,
     loggingApi,
-    schedulerApi
+    schedulerApi,
+    schedulerImpl % "test->test"
   )
 
 val oidc = project

--- a/modules/backend/src/main/scala/docspell/backend/ops/OItemSearch.scala
+++ b/modules/backend/src/main/scala/docspell/backend/ops/OItemSearch.scala
@@ -53,6 +53,8 @@ trait OItemSearch[F[_]] {
 
   def findAttachmentMeta(id: Ident, collective: CollectiveId): F[Option[RAttachmentMeta]]
 
+  def findFile(key: FileKey, collective: CollectiveId): F[Option[BinaryData[F]]]
+
   def findByFileCollective(checksum: String, collective: CollectiveId): F[Vector[RItem]]
 
   def findByFileSource(checksum: String, sourceId: Ident): F[Option[Vector[RItem]]]
@@ -116,6 +118,14 @@ object OItemSearch {
   ) extends BinaryData[F] {
     val name = rs.name
     val fileId = rs.fileId
+  }
+
+  case class FileData[F[_]](
+      meta: FileMetadata,
+      data: Stream[F, Byte]
+  ) extends BinaryData[F] {
+    val name = None
+    val fileId = meta.id
   }
 
   def apply[F[_]: Async](store: Store[F]): Resource[F, OItemSearch[F]] =
@@ -249,6 +259,13 @@ object OItemSearch {
           collective: CollectiveId
       ): F[Option[RAttachmentMeta]] =
         store.transact(QAttachment.getAttachmentMeta(id, collective))
+
+      def findFile(key: FileKey, collective: CollectiveId): F[Option[BinaryData[F]]] =
+        if (key.collective != collective) (None: Option[BinaryData[F]]).pure[F]
+        else
+          makeBinaryData(key) { m =>
+            FileData[F](m, store.fileRepo.getBytes(m.id)): BinaryData[F]
+          }
 
       def findByFileCollective(
           checksum: String,

--- a/modules/backend/src/main/scala/docspell/backend/ops/OUpload.scala
+++ b/modules/backend/src/main/scala/docspell/backend/ops/OUpload.scala
@@ -72,7 +72,8 @@ object OUpload {
       language: Option[Language],
       attachmentsOnly: Option[Boolean],
       flattenArchives: Option[Boolean],
-      customData: Option[Json]
+      customData: Option[Json],
+      priority: Option[Priority]
   )
 
   case class UploadData[F[_]](
@@ -199,7 +200,7 @@ object OUpload {
               attachmentsOnly =
                 data.meta.attachmentsOnly.orElse(src.source.attachmentsOnly.some)
             ),
-            priority = src.source.priority
+            priority = data.meta.priority.getOrElse(src.source.priority)
           )
           result <- OptionT.liftF(submit(updata, src.source.cid, None, itemId))
         } yield result).getOrElse(UploadResult.noSource)

--- a/modules/backend/src/main/scala/docspell/backend/ops/OUpload.scala
+++ b/modules/backend/src/main/scala/docspell/backend/ops/OUpload.scala
@@ -87,9 +87,10 @@ object OUpload {
   object UploadResult {
 
     /** File(s) have been successfully submitted. */
-    case object Success extends UploadResult
+    case class Success(files: List[FileKey], jobs: List[Ident]) extends UploadResult
 
-    def success: UploadResult = Success
+    def success(files: List[FileKey], jobs: List[Ident]): UploadResult =
+      Success(files, jobs)
 
     /** There were no files to submit. */
     case object NoFiles extends UploadResult
@@ -172,7 +173,9 @@ object OUpload {
             )
           )
           _ <- right(logger.debug(s"Storing jobs: $jobs"))
-          res <- right(submitJobs(jobs.map(_.encode)))
+          res <- right(
+            submitJobs(files.map(_.fileMetaId).toList, jobs.map(_.encode))
+          )
           _ <- right(
             store.transact(
               RSource.incrementCounter(data.meta.sourceAbbrev, collectiveId)
@@ -204,11 +207,14 @@ object OUpload {
           result <- OptionT.liftF(submit(updata, src.source.cid, None, itemId))
         } yield result).getOrElse(UploadResult.noSource)
 
-      private def submitJobs(jobs: List[Job[String]]): F[OUpload.UploadResult] =
+      private def submitJobs(
+          files: List[FileKey],
+          jobs: List[Job[String]]
+      ): F[OUpload.UploadResult] =
         for {
           _ <- logger.debug(s"Storing jobs: $jobs")
           _ <- jobStore.insertAll(jobs)
-        } yield UploadResult.Success
+        } yield UploadResult.Success(files, jobs.map(_.id))
 
       /** Saves the file into the database. */
       private def saveFile(

--- a/modules/backend/src/test/scala/docspell/backend/ops/OItemSearchFileTest.scala
+++ b/modules/backend/src/test/scala/docspell/backend/ops/OItemSearchFileTest.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 Eike K. & Contributors
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package docspell.backend.ops
+
+import cats.effect._
+import fs2.Stream
+
+import docspell.common._
+import docspell.store.{DatabaseTest, Store}
+
+class OItemSearchFileTest extends DatabaseTest {
+
+  override def munitFixtures = h2Memory
+
+  test("findFile returns bytes for matching collective") {
+    val store = h2Store()
+    val content = "original-bytes".getBytes("UTF-8")
+
+    OItemSearch[IO](store).use { search =>
+      for {
+        cid <- IO.pure(CollectiveId(42))
+        key <- saveFile(store, cid, content)
+        found <- search.findFile(key, cid)
+        bytes <- found match {
+          case Some(bin) => bin.data.compile.to(Array)
+          case None      => IO.raiseError(new Exception("expected Some"))
+        }
+      } yield {
+        assertEquals(bytes.toSeq, content.toSeq)
+        assertEquals(found.get.fileId, key)
+      }
+    }
+  }
+
+  test("findFile returns None when collective does not match") {
+    val store = h2Store()
+    val content = "secret".getBytes("UTF-8")
+
+    OItemSearch[IO](store).use { search =>
+      for {
+        cid <- IO.pure(CollectiveId(7))
+        other = CollectiveId(8)
+        key <- saveFile(store, cid, content)
+        found <- search.findFile(key, other)
+      } yield assertEquals(found, None)
+    }
+  }
+
+  private def saveFile(
+      store: Store[IO],
+      cid: CollectiveId,
+      content: Array[Byte]
+  ): IO[FileKey] =
+    Stream
+      .emits(content)
+      .covary[IO]
+      .through(
+        store.fileRepo.save(
+          cid,
+          FileCategory.AttachmentSource,
+          MimeTypeHint.filename("a.txt")
+        )
+      )
+      .compile
+      .lastOrError
+}

--- a/modules/backend/src/test/scala/docspell/backend/ops/OUploadTest.scala
+++ b/modules/backend/src/test/scala/docspell/backend/ops/OUploadTest.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Eike K. & Contributors
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package docspell.backend.ops
+
+import cats.effect._
+import fs2.Stream
+
+import docspell.common._
+import docspell.scheduler.impl.JobStoreImpl
+import docspell.store.records.RCollective
+import docspell.store.{DatabaseTest, Store}
+
+class OUploadTest extends DatabaseTest {
+
+  override def munitFixtures = h2Memory
+
+  test("submit returns file keys and job ids for uploaded file") {
+    val store = h2Store()
+    val content = "hello-upload".getBytes("UTF-8")
+
+    OUpload[IO](store, JobStoreImpl(store)).use { upload =>
+      for {
+        cid <- prepareCollective(store)
+        data = OUpload.UploadData(
+          multiple = true,
+          meta = OUpload.UploadMeta(
+            direction = None,
+            sourceAbbrev = "webapp",
+            folderId = None,
+            validFileTypes = Seq.empty,
+            skipDuplicates = false,
+            fileFilter = Glob.all,
+            tags = Nil,
+            language = Some(Language.English),
+            attachmentsOnly = None,
+            flattenArchives = None,
+            customData = None
+          ),
+          files = Vector(
+            OUpload.File(
+              Some("test.txt"),
+              Some(MimeType.plain),
+              Stream.emits(content).covary[IO]
+            )
+          ),
+          priority = Priority.High,
+          tracker = None
+        )
+        result <- upload.submit(data, cid, None, None)
+      } yield result match {
+        case OUpload.UploadResult.Success(files, jobs) =>
+          assertEquals(files.size, 1)
+          assertEquals(jobs.size, 1)
+          assertEquals(files.head.collective, cid)
+          assertEquals(files.head.category, FileCategory.AttachmentSource)
+        case other =>
+          fail(s"expected Success, got $other")
+      }
+    }
+  }
+
+  test("submitted file can be loaded by returned file key") {
+    val store = h2Store()
+    val content = "retrieve-me".getBytes("UTF-8")
+
+    OUpload[IO](store, JobStoreImpl(store)).use { upload =>
+      OItemSearch[IO](store).use { search =>
+        for {
+          cid <- prepareCollective(store)
+          data = OUpload.UploadData(
+            multiple = true,
+            meta = OUpload.UploadMeta(
+              direction = None,
+              sourceAbbrev = "webapp",
+              folderId = None,
+              validFileTypes = Seq.empty,
+              skipDuplicates = false,
+              fileFilter = Glob.all,
+              tags = Nil,
+              language = Some(Language.English),
+              attachmentsOnly = None,
+              flattenArchives = None,
+              customData = None
+            ),
+            files = Vector(
+              OUpload.File(
+                Some("doc.pdf"),
+                None,
+                Stream.emits(content).covary[IO]
+              )
+            ),
+            priority = Priority.Low,
+            tracker = None
+          )
+          result <- upload.submit(data, cid, None, None)
+          loaded <- result match {
+            case OUpload.UploadResult.Success(file :: _, _) =>
+              search.findFile(file, cid)
+            case other =>
+              IO.raiseError(new Exception(s"expected Success, got $other"))
+          }
+          bytes <- loaded match {
+            case Some(bin) => bin.data.compile.to(Array)
+            case None      => IO.raiseError(new Exception("file not found via findFile"))
+          }
+        } yield assertEquals(bytes.toSeq, content.toSeq)
+      }
+    }
+  }
+
+  private def prepareCollective(store: Store[IO]): IO[CollectiveId] =
+    Ident
+      .randomId[IO]
+      .flatMap { name =>
+        store.transact(
+          RCollective.insert(
+            RCollective(
+              CollectiveId.unknown,
+              name,
+              CollectiveState.Active,
+              Language.English,
+              integrationEnabled = true,
+              Timestamp.Epoch
+            )
+          )
+        )
+      }
+}

--- a/modules/joex/src/main/scala/docspell/joex/scanmailbox/ScanMailboxTask.scala
+++ b/modules/joex/src/main/scala/docspell/joex/scanmailbox/ScanMailboxTask.scala
@@ -329,6 +329,7 @@ object ScanMailboxTask {
           args.language,
           args.attachmentsOnly,
           None,
+          None,
           None
         )
         data = OUpload.UploadData(

--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -4716,6 +4716,71 @@ paths:
               schema:
                 type: string
                 format: binary
+  /sec/file/{collectiveId}/{category}/{id}:
+    head:
+      operationId: "sec-file-check"
+      tags: [ Attachment ]
+      summary: Get headers for a file by its file key.
+      description: |
+        Get information about a binary file identified by its file
+        key parts (`collectiveId`, `category`, `id`). The collective
+        in the key must match the authenticated user's collective.
+      security:
+        - authTokenHeader: []
+      parameters:
+        - $ref: "#/components/parameters/collectiveId"
+        - $ref: "#/components/parameters/category"
+        - $ref: "#/components/parameters/id"
+      responses:
+        422:
+          description: BadRequest
+        200:
+          description: Ok
+          headers:
+            Content-Type:
+              schema:
+                type: string
+            Content-Length:
+              schema:
+                type: integer
+                format: int64
+            ETag:
+              schema:
+                type: string
+            Content-Disposition:
+              schema:
+                type: string
+        404:
+          description: Not Found
+    get:
+      operationId: "sec-file-get"
+      tags: [ Attachment ]
+      summary: Download a file by its file key.
+      description: |
+        Get the binary file identified by its file key parts
+        (`collectiveId`, `category`, `id`). The collective in the key
+        must match the authenticated user's collective. This can be
+        used with file keys returned from the upload endpoints to
+        retrieve the original uploaded bytes before processing
+        finishes.
+      security:
+        - authTokenHeader: []
+      parameters:
+        - $ref: "#/components/parameters/collectiveId"
+        - $ref: "#/components/parameters/category"
+        - $ref: "#/components/parameters/id"
+      responses:
+        422:
+          description: BadRequest
+        200:
+          description: Ok
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        404:
+          description: Not Found
   /sec/attachment/{id}/archive:
     head:
       operationId: "sec-attach-check-archive"
@@ -9106,6 +9171,22 @@ components:
       name: id
       in: path
       description: An identifier
+      required: true
+      schema:
+        type: string
+    collectiveId:
+      name: collectiveId
+      in: path
+      description: The numeric collective id
+      required: true
+      schema:
+        type: string
+    category:
+      name: category
+      in: path
+      description: |
+        File category (e.g. attachmentsource, attachmentconvert,
+        previewimage)
       required: true
       schema:
         type: string

--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -219,7 +219,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasicResult"
+                $ref: "#/components/schemas/UploadSubmitResult"
   /open/upload/item/{itemId}/{id}:
     post:
       operationId: "open-upload-to-item-by-source"
@@ -264,7 +264,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasicResult"
+                $ref: "#/components/schemas/UploadSubmitResult"
 
   /admin/fts/reIndexAll:
     post:
@@ -380,7 +380,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasicResult"
+                $ref: "#/components/schemas/UploadSubmitResult"
   /sec/upload/{itemId}:
     post:
       operationId: "sec-upload-to-item"
@@ -427,7 +427,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasicResult"
+                $ref: "#/components/schemas/UploadSubmitResult"
 
   /sec/downloadAll/prefetch:
     post:
@@ -628,7 +628,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/BasicResult"
+                $ref: "#/components/schemas/UploadSubmitResult"
   /open/integration/checkfile/{id}/{checksum}:
     get:
       operationId: "open-integration-checkfile-by-checksum"
@@ -8949,6 +8949,31 @@ components:
           type: boolean
         message:
           type: string
+    UploadSubmitResult:
+      description: |
+        Result of an upload. On success, `fileKeys` and `jobIds`
+        identify the stored files and submitted processing jobs. On
+        failure both lists are empty and not usable. File keys use the
+        form `collectiveId/category/fileId` (same as FileKey.toString).
+      required:
+        - success
+        - message
+        - fileKeys
+        - jobIds
+      properties:
+        success:
+          type: boolean
+        message:
+          type: string
+        fileKeys:
+          type: array
+          items:
+            type: string
+        jobIds:
+          type: array
+          items:
+            type: string
+            format: ident
     IdResult:
       description: |
         Some basic result of an operation with an ID as payload, if

--- a/modules/restapi/src/main/resources/docspell-openapi.yml
+++ b/modules/restapi/src/main/resources/docspell-openapi.yml
@@ -8271,6 +8271,16 @@ components:
             Custom user data that gets threaded through the processing. Docspell
             ignores it completely, but will pass it to the outcome of processing
             to be able to react on it in addons or other ways.
+        priority:
+          type: string
+          format: priority
+          enum:
+            - high
+            - low
+          description: |
+            Processing priority for the upload jobs. If omitted, the endpoint
+            default applies (high for secured upload, source priority for open
+            upload, server config for integration).
 
     Collective:
       description: |

--- a/modules/restserver/src/main/scala/docspell/restserver/RestAppImpl.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/RestAppImpl.scala
@@ -138,6 +138,7 @@ final class RestAppImpl[F[_]: Async: Files](
       "itemlink" -> ItemLinkRoutes(token.account, backend.itemLink),
       "attachment" -> AttachmentRoutes(backend, token),
       "attachments" -> AttachmentMultiRoutes(backend, token),
+      "file" -> FileRoutes(backend, token),
       "upload" -> UploadRoutes.secured(backend, config, token),
       "checkfile" -> CheckFileRoutes.secured(backend, token),
       "email/send" -> MailSendRoutes(backend, token),

--- a/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
@@ -316,7 +316,8 @@ trait Conversions {
               m.language,
               m.attachmentsOnly,
               m.flattenArchives,
-              m.customData
+              m.customData,
+              m.priority
             )
           )
         )
@@ -332,6 +333,7 @@ trait Conversions {
             skipDuplicates = false,
             Glob.all,
             Nil,
+            None,
             None,
             None,
             None,
@@ -355,7 +357,13 @@ trait Conversions {
       metaData <- meta
       _ <- Async[F].delay(logger.debug(s"Parsed upload meta data: $metaData"))
       tracker <- Ident.randomId[F]
-    } yield UploadData(metaData._1, metaData._2, files, prio, Some(tracker))
+    } yield UploadData(
+      metaData._1,
+      metaData._2,
+      files,
+      metaData._2.priority.getOrElse(prio),
+      Some(tracker)
+    )
   }
 
   // organization and person

--- a/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/conv/Conversions.scala
@@ -689,7 +689,7 @@ trait Conversions {
 
   def basicResult(ur: OUpload.UploadResult): BasicResult =
     ur match {
-      case UploadResult.Success => BasicResult(success = true, "Files submitted.")
+      case UploadResult.Success(_, _) => BasicResult(success = true, "Files submitted.")
       case UploadResult.NoFiles =>
         BasicResult(success = false, "There were no files to submit.")
       case UploadResult.NoSource =>
@@ -702,6 +702,52 @@ trait Conversions {
         BasicResult(
           success = false,
           "There were errors storing a file! See the server logs for details."
+        )
+    }
+
+  def uploadSubmitResult(ur: OUpload.UploadResult): UploadSubmitResult =
+    ur match {
+      case UploadResult.Success(files, jobs) =>
+        UploadSubmitResult(
+          success = true,
+          "Files submitted.",
+          files.map(_.toString),
+          jobs
+        )
+      case UploadResult.NoFiles =>
+        UploadSubmitResult(
+          success = false,
+          "There were no files to submit.",
+          Nil,
+          Nil
+        )
+      case UploadResult.NoSource =>
+        UploadSubmitResult(
+          success = false,
+          "The source id is not valid.",
+          Nil,
+          Nil
+        )
+      case UploadResult.NoItem =>
+        UploadSubmitResult(
+          success = false,
+          "The item could not be found.",
+          Nil,
+          Nil
+        )
+      case UploadResult.NoCollective =>
+        UploadSubmitResult(
+          success = false,
+          "The collective could not be found.",
+          Nil,
+          Nil
+        )
+      case UploadResult.StoreFailure(_) =>
+        UploadSubmitResult(
+          success = false,
+          "There were errors storing a file! See the server logs for details.",
+          Nil,
+          Nil
         )
     }
 

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/FileRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/FileRoutes.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Eike K. & Contributors
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package docspell.restserver.routes
+
+import cats.effect._
+import cats.syntax.all._
+
+import docspell.backend.BackendApp
+import docspell.backend.auth.AuthToken
+import docspell.common._
+import docspell.restapi.model.BasicResult
+import docspell.restserver.http4s.BinaryUtil
+
+import org.http4s._
+import org.http4s.circe.CirceEntityEncoder._
+import org.http4s.dsl.Http4sDsl
+
+object FileRoutes {
+
+  def apply[F[_]: Async](
+      backend: BackendApp[F],
+      user: AuthToken
+  ): HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F] {}
+    import dsl._
+
+    HttpRoutes.of {
+      case HEAD -> Root / collStr / catStr / Ident(fid) =>
+        parseFileKey(collStr, catStr, fid) match {
+          case Right(key) =>
+            for {
+              fileData <- backend.itemSearch.findFile(key, user.account.collectiveId)
+              resp <- BinaryUtil.respondHead(dsl)(fileData)
+            } yield resp
+          case Left(msg) =>
+            BadRequest(BasicResult(success = false, msg))
+        }
+
+      case req @ GET -> Root / collStr / catStr / Ident(fid) =>
+        parseFileKey(collStr, catStr, fid) match {
+          case Right(key) =>
+            for {
+              fileData <- backend.itemSearch.findFile(key, user.account.collectiveId)
+              resp <- BinaryUtil.respond(dsl, req)(fileData)
+            } yield resp
+          case Left(msg) =>
+            BadRequest(BasicResult(success = false, msg))
+        }
+    }
+  }
+
+  private def parseFileKey(
+      collStr: String,
+      catStr: String,
+      fid: Ident
+  ): Either[String, FileKey] =
+    for {
+      cid <- CollectiveId.fromString(collStr)
+      cat <- FileCategory.fromString(catStr)
+    } yield FileKey(cid, cat, fid)
+}

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/IntegrationEndpointRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/IntegrationEndpointRoutes.scala
@@ -110,7 +110,7 @@ object IntegrationEndpointRoutes {
         cfg.backend.files.validMimeTypes
       )
       result <- backend.upload.submit(updata, cid, None, None)
-      res <- Ok(basicResult(result))
+      res <- Ok(uploadSubmitResult(result))
     } yield res
   }
 

--- a/modules/restserver/src/main/scala/docspell/restserver/routes/UploadRoutes.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/routes/UploadRoutes.scala
@@ -110,7 +110,7 @@ object UploadRoutes {
           cfg.backend.files.validMimeTypes
         )
         result <- backend.upload.submitEither(updata, accOrSrc, userId, itemId)
-        res <- Ok(basicResult(result))
+        res <- Ok(uploadSubmitResult(result))
       } yield res
     }
   }

--- a/modules/restserver/src/test/scala/docspell/restserver/conv/UploadSubmitResultTest.scala
+++ b/modules/restserver/src/test/scala/docspell/restserver/conv/UploadSubmitResultTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Eike K. & Contributors
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+package docspell.restserver.conv
+
+import docspell.backend.ops.OUpload
+import docspell.common._
+import docspell.restapi.model.UploadSubmitResult
+
+import munit.FunSuite
+
+class UploadSubmitResultTest extends FunSuite with Conversions {
+
+  test("map Success to UploadSubmitResult with fileKeys and jobIds") {
+    val fileKey =
+      FileKey(CollectiveId(1), FileCategory.AttachmentSource, Ident.unsafe("file-1"))
+    val jobId = Ident.unsafe("job-1")
+    val result =
+      uploadSubmitResult(OUpload.UploadResult.Success(List(fileKey), List(jobId)))
+
+    assertEquals(
+      result,
+      UploadSubmitResult(
+        success = true,
+        "Files submitted.",
+        List(fileKey.toString),
+        List(jobId)
+      )
+    )
+  }
+
+  test("map failures to empty fileKeys and jobIds") {
+    val cases = List(
+      OUpload.UploadResult.NoFiles,
+      OUpload.UploadResult.NoSource,
+      OUpload.UploadResult.NoItem,
+      OUpload.UploadResult.NoCollective,
+      OUpload.UploadResult.StoreFailure(new RuntimeException("boom"))
+    )
+
+    cases.foreach { ur =>
+      val result = uploadSubmitResult(ur)
+      assertEquals(result.success, false)
+      assertEquals(result.fileKeys, Nil)
+      assertEquals(result.jobIds, Nil)
+    }
+  }
+}

--- a/modules/webapp/src/main/elm/Comp/UploadForm.elm
+++ b/modules/webapp/src/main/elm/Comp/UploadForm.elm
@@ -16,6 +16,7 @@ import Comp.Progress
 import Data.DropdownStyle as DS
 import Data.Flags exposing (Flags)
 import Data.Language exposing (Language)
+import Data.Priority exposing (Priority)
 import Data.UiSettings exposing (UiSettings)
 import Dict exposing (Dict)
 import File exposing (File)
@@ -43,6 +44,8 @@ type alias Model =
     , skipDuplicates : Bool
     , languageModel : Comp.FixedDropdown.Model Language
     , language : Maybe Language
+    , priorityModel : Comp.FixedDropdown.Model Priority
+    , priority : Priority
     , flattenArchives : Bool
     , uploadDone : Maybe Bool
     }
@@ -58,6 +61,7 @@ type Msg
     | DropzoneMsg Comp.Dropzone.Msg
     | ToggleSkipDuplicates
     | LanguageMsg (Comp.FixedDropdown.Msg Language)
+    | PrioDropdownMsg (Comp.FixedDropdown.Msg Priority)
     | ToggleFlattenArchives
 
 
@@ -74,6 +78,9 @@ init =
     , languageModel =
         Comp.FixedDropdown.init Data.Language.all
     , language = Nothing
+    , priorityModel =
+        Comp.FixedDropdown.init Data.Priority.all
+    , priority = Data.Priority.High
     , flattenArchives = False
     , uploadDone = Nothing
     }
@@ -192,6 +199,7 @@ update sourceId flags msg model =
                                 Just "outgoing"
                         , language = Maybe.map Data.Language.toIso3 model.language
                         , flattenArchives = Just model.flattenArchives
+                        , priority = Just (Data.Priority.toName model.priority)
                     }
 
                 fileids =
@@ -342,6 +350,19 @@ update sourceId flags msg model =
             , Sub.none
             )
 
+        PrioDropdownMsg pm ->
+            let
+                ( m2, p2 ) =
+                    Comp.FixedDropdown.update pm model.priorityModel
+            in
+            ( { model
+                | priorityModel = m2
+                , priority = Maybe.withDefault model.priority p2
+              }
+            , Cmd.none
+            , Sub.none
+            )
+
 
 setCompleted : Model -> String -> Set String
 setCompleted model fileid =
@@ -428,6 +449,13 @@ renderForm texts model =
             , style = DS.mainStyleWith "w-40"
             , selectPlaceholder = texts.basics.selectPlaceholder
             }
+
+        priorityCfg =
+            { display = Data.Priority.toName
+            , icon = \_ -> Nothing
+            , style = DS.mainStyleWith "w-40"
+            , selectPlaceholder = texts.basics.selectPlaceholder
+            }
     in
     div [ class "row" ]
         [ Html.form [ action "#" ]
@@ -508,6 +536,21 @@ renderForm texts model =
                     ]
                 , div [ class "text-gray-400 text-xs" ]
                     [ text texts.languageInfo
+                    ]
+                ]
+            , div [ class "flex flex-col mb-3" ]
+                [ label [ class "inline-flex items-center mb-2" ]
+                    [ span [ class "mr-2" ] [ text (texts.priority ++ ":") ]
+                    , Html.map PrioDropdownMsg
+                        (Comp.FixedDropdown.viewStyled2
+                            priorityCfg
+                            False
+                            (Just model.priority)
+                            model.priorityModel
+                        )
+                    ]
+                , div [ class "text-gray-400 text-xs" ]
+                    [ text texts.priorityInfo
                     ]
                 ]
             ]

--- a/modules/webapp/src/main/elm/Messages/Comp/UploadForm.elm
+++ b/modules/webapp/src/main/elm/Messages/Comp/UploadForm.elm
@@ -36,6 +36,8 @@ type alias Texts =
     , selectedFiles : String
     , languageLabel : Language -> String
     , flattenArchives : String
+    , priority : String
+    , priorityInfo : String
     }
 
 
@@ -67,6 +69,8 @@ gb =
     , selectedFiles = "Selected Files"
     , languageLabel = Messages.Data.Language.gb
     , flattenArchives = "Extract zip file contents into separate items, in contrast to a single document with multiple attachments."
+    , priority = "Priority"
+    , priorityInfo = "The priority used by the scheduler when processing uploaded files."
     }
 
 
@@ -98,6 +102,8 @@ de =
     , selectedFiles = "Ausgewählte Dateien"
     , languageLabel = Messages.Data.Language.de
     , flattenArchives = "ZIP Dateien in separate Dokumente entpacken, anstatt ein Dokument mit mehreren Anhängen."
+    , priority = "Priorität"
+    , priorityInfo = "Die Priorität, die für die Hintergrundaufgabe zur Verarbeitung verwendet wird."
     }
 
 
@@ -129,4 +135,6 @@ fr =
     , selectedFiles = "Fichiers séléctionnés"
     , languageLabel = Messages.Data.Language.fr
     , flattenArchives = "Décompresser les fichiers ZIP dans des documents séparés au lieu de créer un document avec plusieurs pièces jointes."
+    , priority = "Priorité"
+    , priorityInfo = "Ordre de priorité utilisé par le programmateur lors du traitement des fichiers envoyés."
     }

--- a/website/site/content/docs/api/upload.md
+++ b/website/site/content/docs/api/upload.md
@@ -54,6 +54,7 @@ specified via a JSON structure in a part with name `meta`:
 , language: Maybe String
 , attachmentsOnly: Maybe Bool
 , flattenArchives: Maybe Bool
+, priority: Maybe String
 }
 ```
 
@@ -109,6 +110,13 @@ specified via a JSON structure in a part with name `meta`:
   only its contents are. Also note that only the uploaded archive
   files are extracted once (not recursively), so if it contains other
   archive files, they are treated as normal.
+- The `priority` field sets the processing priority for the upload
+  jobs. It can be `high` or `low` and controls how soon the scheduler
+  picks up the jobs relative to other work. If omitted, the endpoint
+  default applies: `high` for authenticated (webapp) uploads, the
+  source's configured priority for open uploads via a source URL, and
+  the server configuration for the integration endpoint. When
+  specified, it overrides the source's default priority.
 
 # Endpoints
 

--- a/website/site/content/docs/webapp/uploading.md
+++ b/website/site/content/docs/webapp/uploading.md
@@ -77,9 +77,14 @@ line::
 
 ``` bash
 $ curl -XPOST -F file=@test.pdf http://192.168.1.95:7880/api/v1/open/upload/item/3H7hvJcDJuk-NrAW4zxsdfj-K6TMPyb6BGP-xKptVxUdqWa
-{"success":true,"message":"Files submitted."}
+{"success":true,"message":"Files submitted.","fileKeys":["1/attachmentsource/…"],"jobIds":["…"]}
 ```
 
+On success the response includes `fileKeys` (stored file identifiers) and
+`jobIds` (submitted processing jobs). Authenticated clients can download
+an original upload immediately via
+`/api/v1/sec/file/{collectiveId}/{category}/{id}` using a returned file
+key.
 There is a [cli](@/docs/tools/cli.md) to upload files from the command
 line more conveniently.
 


### PR DESCRIPTION
## Summary

This PR extends the upload API so clients can track submitted files and jobs immediately, and retrieve uploaded bytes before joex processing finishes.

- Upload endpoints now return `fileKeys` and `jobIds` on success (replacing the generic `BasicResult` response).
- A new secured endpoint `GET/HEAD /api/v1/sec/file/{collectiveId}/{category}/{id}` downloads files by file key.
- Access is scoped to the authenticated user's collective (wrong collective → 404).

**Use case:** App A uploads a document to Docspell; App B needs the original file right away without waiting for item processing to complete. Closes #3337

## Changes

### Upload response
- `OUpload.Success` now carries `files: List[FileKey]` and `jobs: List[Ident]`
- REST conversion exposes `UploadSubmitResult` with `fileKeys` and `jobIds`
- OpenAPI updated for all upload 200 responses
- Docs: `website/site/content/docs/webapp/uploading.md`

### File download
- `OItemSearch.findFile(key, collective)` loads stored bytes with collective scoping
- New `FileRoutes` mounted at `/api/v1/sec/file/...`
- OpenAPI documents the new endpoint and path parameters

### Tests
- `OUploadTest` — upload returns file keys + job ids; returned key is downloadable
- `OItemSearchFileTest` — content retrieval + collective scoping
- `UploadSubmitResultTest` — conversion mapping

## Example

**Upload**
```http
POST /api/v1/sec/upload/item
X-Docspell-Auth: <token>
Content-Type: multipart/form-data
```

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/7a0f9612-434a-46bc-9a37-79d471e882d6" />
