### PR TITLE
Fix restserver node registration to use internal-url for housekeeping

### DIFF
--- a/modules/backend/src/main/scala/docspell/backend/joex/AddonPrepare.scala
+++ b/modules/backend/src/main/scala/docspell/backend/joex/AddonPrepare.scala
@@ -67,13 +67,21 @@ private[joex] class AddonPrepare[F[_]: Sync](store: Store[F]) extends LoggerExte
           .findAll(NodeType.Restserver)
           .map(_.sortBy(_.updated).lastOption)
       )
+      secret <- serverNode.flatMap(_.serverSecret) match {
+        case Some(value) =>
+          value.pure[F]
+        case None =>
+          val msg =
+            "No restserver node with server secret found. " +
+              "Ensure the restserver is running and registered in the node table."
+          Sync[F].raiseError[ByteVector](new IllegalStateException(msg))
+      }
       url = serverNode.map(_.url).map(u => "DSC_DOCSPELL_URL" -> u.asString)
-      secret = serverNode.flatMap(_.serverSecret)
 
       token <- AuthToken.user(
         account,
         requireSecondFactor = false,
-        secret.getOrElse(ByteVector.empty),
+        secret,
         tokenValidity.some
       )
       session = ("DSC_SESSION" -> token.asString).some

--- a/modules/restserver/src/main/resources/reference.conf
+++ b/modules/restserver/src/main/resources/reference.conf
@@ -18,7 +18,9 @@ docspell.server {
   # This url is the base url for reaching this server internally.
   # While you might set `base-url` to some external address (like
   # mydocs.myserver.com), the `internal-url` must be set such that
-  # other nodes can reach this server.
+  # other nodes can reach this server. It is also used to register
+  # this node in the database for inter-node health checks and addon
+  # authentication.
   internal-url = "http://localhost:7880"
 
   # Configures logging

--- a/modules/restserver/src/main/scala/docspell/restserver/RestServer.scala
+++ b/modules/restserver/src/main/scala/docspell/restserver/RestServer.scala
@@ -102,7 +102,7 @@ object RestServer {
       _ <- nodes.withRegistered(
         cfg.appId,
         NodeType.Restserver,
-        cfg.baseUrl,
+        cfg.internalUrl,
         cfg.auth.serverSecret.some
       )
 

--- a/modules/store/src/main/scala/docspell/store/records/RNode.scala
+++ b/modules/store/src/main/scala/docspell/store/records/RNode.scala
@@ -75,6 +75,7 @@ object RNode {
           t.nodeType.setTo(v.nodeType),
           t.url.setTo(v.url),
           t.serverSecret.setTo(v.serverSecret),
+          t.notFound.setTo(0),
           t.updated.setTo(v.updated)
         )
       )


### PR DESCRIPTION
## Summary

I have made this change to fix the error where nodes unexpectedly get un registered. Please find my AI summary below. Already did a smoke test locally, and it all works fine :).

Fixes #2868.

In Docker deployments, setting `DOCSPELL_SERVER_BASE__URL` to a hostname reachable between containers breaks browser login, while leaving it at `localhost` causes JOEX housekeeping to delete the restserver node row after failed health checks — leading to addon auth failures with `java.lang.IllegalArgumentException: Empty key`.

This PR:

- Registers the restserver in the `node` table using `internal-url` instead of `base-url`, so inter-node health checks use the Docker-internal address while the browser keeps using `base-url`.
- Resets `not_found` to 0 when a node re-registers, so a recovered restserver is not immediately removed again.
- Fails fast in `AddonPrepare` with a clear error when no restserver secret is available, instead of silently using an empty key.

## Test plan

- [x] Local smoke test: restserver starts, signup/login works with default `base-url` and `internal-url=http://localhost:7880`
- [x] JOEX starts against the same database and processes jobs
- [x] Docker: `internal-url=http://docspell-restserver:7880`, default `base-url` — restserver row persists in `node` table, addon auth succeeds
- [x] Browser login still works when accessing via host IP 


Made with [Cursor](https://cursor.com)